### PR TITLE
chore(page name): changed page names from design kit

### DIFF
--- a/alva/page-design-kit.yaml
+++ b/alva/page-design-kit.yaml
@@ -1,4 +1,4 @@
-name: designkit
+name: Design Kit
 root:
   _type: pattern
   pattern: atoms/layout

--- a/alva/page-homepage.yaml
+++ b/alva/page-homepage.yaml
@@ -1,4 +1,4 @@
-name: homepage
+name: Homepage
 root:
   _type: pattern
   pattern: atoms/layout

--- a/alva/page-playground.yaml
+++ b/alva/page-playground.yaml
@@ -1,4 +1,4 @@
-name: playground
+name: Playground
 root:
   _type: pattern
   pattern: atoms/layout

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "stacked-example",
+	"name": "meetalva-designkit",
 	"version": "1.0.0",
 	"description": "",
 	"main": "index.js",
@@ -11,12 +11,12 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/stackedapp/stacked-example.git"
+		"url": "git+https://github.com/meetalva/designkit.git"
 	},
 	"author": "",
 	"license": "MIT",
 	"bugs": {
-		"url": "https://github.com/stackedapp/stacked-example/issues"
+		"url": "https://github.com/meetalva/designkit/issues"
 	},
 	"devDependencies": {
 		"@patternplate/cli": "^2.0.0-4",


### PR DESCRIPTION
The name displayed in the same format as the Page ids. Mostly because of the name in the yml files 