### PR TITLE
chore(package): upgrade styled-components to 2.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
 			"integrity": "sha512-3IaakAC5B4bHJ0aCUKVw0pt+GruavdgWDFbf7TfKh7ZJ8yQuUp7af7MNwf3e+jH8776cjqYmMO1JNDDAE9WfrA==",
 			"dev": true,
 			"requires": {
-				"core-js": "2.5.6",
-				"regenerator-runtime": "0.11.1"
+				"core-js": "^2.5.3",
+				"regenerator-runtime": "^0.11.1"
 			},
 			"dependencies": {
 				"core-js": {
@@ -34,7 +34,7 @@
 			"integrity": "sha1-WT4NFtHW67qZlIk6TMkz0bISrgw=",
 			"dev": true,
 			"requires": {
-				"@commitlint/core": "5.2.8",
+				"@commitlint/core": "^5.2.8",
 				"babel-polyfill": "6.26.0",
 				"chalk": "2.3.0",
 				"get-stdin": "5.0.1",
@@ -49,7 +49,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -58,9 +58,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				},
 				"get-stdin": {
@@ -81,7 +81,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
@@ -98,17 +98,17 @@
 			"integrity": "sha1-oEob6y0lyLcLGdTDCa9QkC1PEFc=",
 			"dev": true,
 			"requires": {
-				"@commitlint/execute-rule": "5.2.8",
-				"@commitlint/is-ignored": "5.2.8",
-				"@commitlint/parse": "5.2.8",
-				"@commitlint/resolve-extends": "5.2.8",
-				"@commitlint/rules": "5.2.8",
-				"@commitlint/top-level": "5.2.8",
-				"@marionebl/sander": "0.6.1",
-				"babel-runtime": "6.26.0",
-				"chalk": "2.3.0",
-				"cosmiconfig": "3.1.0",
-				"git-raw-commits": "1.3.0",
+				"@commitlint/execute-rule": "^5.2.8",
+				"@commitlint/is-ignored": "^5.2.8",
+				"@commitlint/parse": "^5.2.8",
+				"@commitlint/resolve-extends": "^5.2.8",
+				"@commitlint/rules": "^5.2.8",
+				"@commitlint/top-level": "^5.2.8",
+				"@marionebl/sander": "^0.6.0",
+				"babel-runtime": "^6.23.0",
+				"chalk": "^2.0.1",
+				"cosmiconfig": "^3.0.1",
+				"git-raw-commits": "^1.3.0",
 				"lodash.merge": "4.6.0",
 				"lodash.mergewith": "4.6.0",
 				"lodash.pick": "4.4.0",
@@ -122,7 +122,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -131,9 +131,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				},
 				"git-raw-commits": {
@@ -142,11 +142,11 @@
 					"integrity": "sha1-C8hZbpDV/+c29/VUa9LRL3OrqsY=",
 					"dev": true,
 					"requires": {
-						"dargs": "4.1.0",
-						"lodash.template": "4.4.0",
-						"meow": "3.7.0",
-						"split2": "2.2.0",
-						"through2": "2.0.3"
+						"dargs": "^4.0.1",
+						"lodash.template": "^4.0.2",
+						"meow": "^3.3.0",
+						"split2": "^2.0.0",
+						"through2": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -161,8 +161,8 @@
 					"integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
 					"dev": true,
 					"requires": {
-						"lodash._reinterpolate": "3.0.0",
-						"lodash.templatesettings": "4.1.0"
+						"lodash._reinterpolate": "~3.0.0",
+						"lodash.templatesettings": "^4.0.0"
 					}
 				},
 				"lodash.templatesettings": {
@@ -171,7 +171,7 @@
 					"integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
 					"dev": true,
 					"requires": {
-						"lodash._reinterpolate": "3.0.0"
+						"lodash._reinterpolate": "~3.0.0"
 					}
 				},
 				"split2": {
@@ -180,7 +180,7 @@
 					"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
 					"dev": true,
 					"requires": {
-						"through2": "2.0.3"
+						"through2": "^2.0.2"
 					}
 				},
 				"supports-color": {
@@ -189,7 +189,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
@@ -237,8 +237,8 @@
 			"integrity": "sha1-JCTr3iwpJfMRnPr7bWBUlPJb6u0=",
 			"dev": true,
 			"requires": {
-				"conventional-changelog-angular": "1.6.0",
-				"conventional-commits-parser": "2.1.0"
+				"conventional-changelog-angular": "^1.3.3",
+				"conventional-commits-parser": "^2.1.0"
 			},
 			"dependencies": {
 				"conventional-changelog-angular": {
@@ -247,8 +247,8 @@
 					"integrity": "sha1-CiagcfLJ/PzyuGugz79uYwG3W/o=",
 					"dev": true,
 					"requires": {
-						"compare-func": "1.3.2",
-						"q": "1.5.1"
+						"compare-func": "^1.3.1",
+						"q": "^1.4.1"
 					}
 				},
 				"conventional-commits-parser": {
@@ -257,13 +257,13 @@
 					"integrity": "sha512-8MD05yN0Zb6aRsZnFX1ET+8rHWfWJk+my7ANCJZBU2mhz7TSB1fk2vZhkrwVy/PCllcTYAP/1T1NiWQ7Z01mKw==",
 					"dev": true,
 					"requires": {
-						"JSONStream": "1.3.1",
-						"is-text-path": "1.0.1",
-						"lodash": "4.17.4",
-						"meow": "3.7.0",
-						"split2": "2.2.0",
-						"through2": "2.0.3",
-						"trim-off-newlines": "1.0.1"
+						"JSONStream": "^1.0.4",
+						"is-text-path": "^1.0.0",
+						"lodash": "^4.2.1",
+						"meow": "^3.3.0",
+						"split2": "^2.0.0",
+						"through2": "^2.0.0",
+						"trim-off-newlines": "^1.0.0"
 					}
 				},
 				"split2": {
@@ -272,7 +272,7 @@
 					"integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
 					"dev": true,
 					"requires": {
-						"through2": "2.0.3"
+						"through2": "^2.0.2"
 					}
 				}
 			}
@@ -283,17 +283,17 @@
 			"integrity": "sha1-GtbartfMyw/1icFLUQ60Yl5Q+IM=",
 			"dev": true,
 			"requires": {
-				"@commitlint/core": "5.2.8",
-				"babel-runtime": "6.26.0",
-				"chalk": "2.3.0",
+				"@commitlint/core": "^5.2.8",
+				"babel-runtime": "^6.23.0",
+				"chalk": "^2.0.0",
 				"lodash.camelcase": "4.3.0",
 				"lodash.kebabcase": "4.1.1",
 				"lodash.snakecase": "4.1.1",
 				"lodash.startcase": "4.4.0",
 				"lodash.topairs": "4.3.0",
 				"lodash.upperfirst": "4.3.1",
-				"throat": "4.1.0",
-				"vorpal": "1.12.0"
+				"throat": "^4.1.0",
+				"vorpal": "^1.10.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -302,7 +302,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -311,9 +311,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				},
 				"has-flag": {
@@ -328,7 +328,7 @@
 					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^2.0.0"
 					}
 				}
 			}
@@ -339,7 +339,7 @@
 			"integrity": "sha1-byhqivZvqsCSQ6yjRL2vuzcvh5I=",
 			"dev": true,
 			"requires": {
-				"@commitlint/prompt": "5.2.8",
+				"@commitlint/prompt": "^5.2.8",
 				"execa": "0.8.0",
 				"meow": "3.7.0"
 			},
@@ -350,13 +350,13 @@
 					"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				}
 			}
@@ -370,9 +370,9 @@
 				"babel-runtime": "6.26.0",
 				"lodash.merge": "4.6.0",
 				"lodash.omit": "4.5.0",
-				"require-uncached": "1.0.3",
-				"resolve-from": "4.0.0",
-				"resolve-global": "0.1.0"
+				"require-uncached": "^1.0.3",
+				"resolve-from": "^4.0.0",
+				"resolve-global": "^0.1.0"
 			}
 		},
 		"@commitlint/rules": {
@@ -381,10 +381,10 @@
 			"integrity": "sha1-olGRY7/8G4XNBsPKWE+MWVboyOY=",
 			"dev": true,
 			"requires": {
-				"@commitlint/ensure": "5.2.8",
-				"@commitlint/message": "5.2.8",
-				"@commitlint/to-lines": "5.2.8",
-				"babel-runtime": "6.26.0"
+				"@commitlint/ensure": "^5.2.8",
+				"@commitlint/message": "^5.2.8",
+				"@commitlint/to-lines": "^5.2.8",
+				"babel-runtime": "^6.23.0"
 			}
 		},
 		"@commitlint/to-lines": {
@@ -399,7 +399,7 @@
 			"integrity": "sha1-zNMcVJZpXg7hKAhdRabHzYS7YMg=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0"
+				"find-up": "^2.1.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -408,7 +408,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				}
 			}
@@ -419,7 +419,7 @@
 			"integrity": "sha1-RXvNFifwz6V4ulrfze8/VuwlRl8=",
 			"dev": true,
 			"requires": {
-				"@commitlint/cli": "5.2.8",
+				"@commitlint/cli": "^5.2.8",
 				"babel-runtime": "6.26.0",
 				"execa": "0.8.0"
 			},
@@ -430,13 +430,13 @@
 					"integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "5.1.0",
-						"get-stream": "3.0.0",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^5.0.1",
+						"get-stream": "^3.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				}
 			}
@@ -447,9 +447,9 @@
 			"integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2"
+				"graceful-fs": "^4.1.3",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.2"
 			}
 		},
 		"@mrmlnc/readdir-enhanced": {
@@ -458,8 +458,8 @@
 			"integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
 			"dev": true,
 			"requires": {
-				"call-me-maybe": "1.0.1",
-				"glob-to-regexp": "0.3.0"
+				"call-me-maybe": "^1.0.1",
+				"glob-to-regexp": "^0.3.0"
 			}
 		},
 		"@nodelib/fs.stat": {
@@ -474,28 +474,28 @@
 			"integrity": "sha1-dSW33k4tlGuQ46r11AcjQmgSdjU=",
 			"dev": true,
 			"requires": {
-				"@marionebl/sander": "0.6.1",
-				"@patternplate/compiler": "2.5.5",
-				"@patternplate/load-config": "2.5.2",
-				"@patternplate/load-docs": "2.5.2",
-				"@patternplate/load-meta": "2.5.2",
-				"@patternplate/validate-config": "2.5.2",
-				"aggregate-error": "1.0.0",
-				"arson": "0.2.6",
-				"chokidar": "1.7.0",
-				"common-dir": "1.0.1",
-				"dargs": "5.1.0",
-				"express": "4.16.3",
-				"glob-parent": "3.1.0",
-				"memory-fs": "0.4.1",
-				"micromatch": "3.1.10",
-				"require-from-string": "2.0.1",
-				"resolve-pkg": "1.0.0",
-				"string-hash": "1.1.3",
-				"unindent": "2.0.0",
-				"ws": "4.1.0",
-				"yargs-parser": "9.0.2",
-				"zen-observable": "0.7.1"
+				"@marionebl/sander": "^0.6.1",
+				"@patternplate/compiler": "^2.5.5",
+				"@patternplate/load-config": "^2.5.2",
+				"@patternplate/load-docs": "^2.5.2",
+				"@patternplate/load-meta": "^2.5.2",
+				"@patternplate/validate-config": "^2.5.2",
+				"aggregate-error": "^1.0.0",
+				"arson": "^0.2.6",
+				"chokidar": "^1.7.0",
+				"common-dir": "^1.0.1",
+				"dargs": "^5.1.0",
+				"express": "^4.16.2",
+				"glob-parent": "^3.1.0",
+				"memory-fs": "^0.4.1",
+				"micromatch": "^3.1.8",
+				"require-from-string": "^2.0.1",
+				"resolve-pkg": "^1.0.0",
+				"string-hash": "^1.1.3",
+				"unindent": "^2.0.0",
+				"ws": "^4.0.0",
+				"yargs-parser": "^9.0.2",
+				"zen-observable": "^0.7.1"
 			},
 			"dependencies": {
 				"dargs": {
@@ -512,32 +512,32 @@
 			"integrity": "sha1-hVmFzLjoaHdetazupu6Mee06DRY=",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "7.0.0-beta.47",
-				"@marionebl/sander": "0.6.1",
-				"@patternplate/client": "2.5.8",
-				"@patternplate/compiler": "2.5.5",
-				"@patternplate/create-default": "2.5.2",
-				"@patternplate/load-config": "2.5.2",
-				"@patternplate/load-docs": "2.5.2",
-				"@patternplate/load-meta": "2.5.2",
-				"@patternplate/validate-config": "2.5.2",
-				"arson": "0.2.6",
-				"chalk": "2.4.1",
-				"command-exists": "1.2.6",
-				"errorhandler": "1.5.0",
-				"execa": "0.9.0",
-				"express": "4.16.3",
-				"express-slash": "2.0.1",
-				"import-fresh": "2.0.0",
-				"import-from": "2.1.0",
-				"memory-fs": "0.4.1",
-				"meow": "3.7.0",
-				"ora": "2.1.0",
-				"require-from-string": "2.0.1",
-				"resolve-from": "4.0.0",
-				"resolve-pkg": "1.0.0",
-				"string-hash": "1.1.3",
-				"unindent": "2.0.0"
+				"@babel/runtime": "^7.0.0-beta.40",
+				"@marionebl/sander": "^0.6.1",
+				"@patternplate/client": "^2.5.8",
+				"@patternplate/compiler": "^2.5.5",
+				"@patternplate/create-default": "^2.5.2",
+				"@patternplate/load-config": "^2.5.2",
+				"@patternplate/load-docs": "^2.5.2",
+				"@patternplate/load-meta": "^2.5.2",
+				"@patternplate/validate-config": "^2.5.2",
+				"arson": "^0.2.6",
+				"chalk": "^2.3.2",
+				"command-exists": "^1.2.2",
+				"errorhandler": "^1.5.0",
+				"execa": "^0.9.0",
+				"express": "^4.16.2",
+				"express-slash": "^2.0.1",
+				"import-fresh": "^2.0.0",
+				"import-from": "^2.1.0",
+				"memory-fs": "^0.4.1",
+				"meow": "^3.7.0",
+				"ora": "^2.0.0",
+				"require-from-string": "^2.0.1",
+				"resolve-from": "^4.0.0",
+				"resolve-pkg": "^1.0.0",
+				"string-hash": "^1.1.3",
+				"unindent": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -546,7 +546,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -555,9 +555,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -572,7 +572,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -583,19 +583,19 @@
 			"integrity": "sha1-tuEYI0YrfCwsFSQBDzAwwEch/ek=",
 			"dev": true,
 			"requires": {
-				"@patternplate/api": "2.5.6",
-				"@patternplate/load-config": "2.5.2",
-				"@patternplate/load-docs": "2.5.2",
-				"@patternplate/load-meta": "2.5.2",
-				"buble": "0.19.3",
-				"cors": "2.8.4",
-				"express": "4.16.3",
-				"globby": "8.0.1",
-				"iframe-resizer": "3.6.1",
-				"isomorphic-fetch": "2.2.1",
-				"load-json-file": "4.0.0",
-				"memory-fs": "0.4.1",
-				"serve-static": "1.13.2"
+				"@patternplate/api": "^2.5.6",
+				"@patternplate/load-config": "^2.5.2",
+				"@patternplate/load-docs": "^2.5.2",
+				"@patternplate/load-meta": "^2.5.2",
+				"buble": "^0.19.3",
+				"cors": "^2.8.4",
+				"express": "^4.16.2",
+				"globby": "^8.0.1",
+				"iframe-resizer": "^3.6.0",
+				"isomorphic-fetch": "^2.0.2",
+				"load-json-file": "^4.0.0",
+				"memory-fs": "^0.4.1",
+				"serve-static": "^1.13.2"
 			}
 		},
 		"@patternplate/compiler": {
@@ -604,20 +604,20 @@
 			"integrity": "sha1-zkom9INHu25OHNse/u+yDGHeWlU=",
 			"dev": true,
 			"requires": {
-				"@patternplate/cover-client": "2.5.2",
-				"@patternplate/demo-client": "2.5.2",
-				"@patternplate/load-config": "2.5.2",
-				"@patternplate/probe-client": "2.5.2",
-				"@patternplate/webpack-entry": "2.5.2",
-				"css-loader": "0.28.11",
-				"html-loader": "0.5.5",
-				"loader-utils": "1.1.0",
-				"memory-fs": "0.4.1",
-				"read-pkg": "3.0.0",
-				"resolve-from": "4.0.0",
-				"to-string-loader": "1.1.5",
-				"webpack": "4.8.3",
-				"webpack-node-externals": "1.7.2"
+				"@patternplate/cover-client": "^2.5.2",
+				"@patternplate/demo-client": "^2.5.2",
+				"@patternplate/load-config": "^2.5.2",
+				"@patternplate/probe-client": "^2.5.2",
+				"@patternplate/webpack-entry": "^2.5.2",
+				"css-loader": "^0.28.10",
+				"html-loader": "^0.5.5",
+				"loader-utils": "^1.1.0",
+				"memory-fs": "^0.4.1",
+				"read-pkg": "^3.0.0",
+				"resolve-from": "^4.0.0",
+				"to-string-loader": "^1.1.5",
+				"webpack": "^4.5.0",
+				"webpack-node-externals": "^1.6.0"
 			},
 			"dependencies": {
 				"path-type": {
@@ -626,7 +626,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
@@ -641,9 +641,9 @@
 					"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "4.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "3.0.0"
+						"load-json-file": "^4.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^3.0.0"
 					}
 				}
 			}
@@ -666,7 +666,7 @@
 			"integrity": "sha1-jWshA+Od41Hhwxrx3IbEzBz+ldY=",
 			"dev": true,
 			"requires": {
-				"iframe-resizer": "3.6.1"
+				"iframe-resizer": "^3.6.0"
 			}
 		},
 		"@patternplate/load-config": {
@@ -675,9 +675,9 @@
 			"integrity": "sha1-AoXuVCcPYZTH29xBo9avST3fKBU=",
 			"dev": true,
 			"requires": {
-				"@patternplate/render-default": "2.5.2",
-				"cosmiconfig": "3.1.0",
-				"resolve-from": "4.0.0"
+				"@patternplate/render-default": "^2.5.2",
+				"cosmiconfig": "^3.1.0",
+				"resolve-from": "^4.0.0"
 			}
 		},
 		"@patternplate/load-doc": {
@@ -686,8 +686,8 @@
 			"integrity": "sha1-amW9D9FM/Ot2jYmdeGIPPU1+FSM=",
 			"dev": true,
 			"requires": {
-				"@marionebl/sander": "0.6.1",
-				"globby": "6.1.0"
+				"@marionebl/sander": "^0.6.1",
+				"globby": "^6.1.0"
 			},
 			"dependencies": {
 				"globby": {
@@ -696,11 +696,11 @@
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"glob": "7.1.2",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
@@ -711,13 +711,13 @@
 			"integrity": "sha1-EPtB6BOwiPjaS+vcEMxlpk5UOe0=",
 			"dev": true,
 			"requires": {
-				"@marionebl/sander": "0.6.1",
-				"front-matter": "2.3.0",
-				"globby": "6.1.0",
-				"lodash": "4.17.4",
-				"remark": "8.0.0",
-				"shortid": "2.2.8",
-				"unist-util-find": "1.0.1"
+				"@marionebl/sander": "^0.6.1",
+				"front-matter": "^2.2.0",
+				"globby": "^6.1.0",
+				"lodash": "^4.17.4",
+				"remark": "^8.0.0",
+				"shortid": "^2.2.8",
+				"unist-util-find": "^1.0.1"
 			},
 			"dependencies": {
 				"globby": {
@@ -726,11 +726,11 @@
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"glob": "7.1.2",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
@@ -741,8 +741,8 @@
 			"integrity": "sha1-94ZtfFkS9a5Mx45eFPpm9WvC/Cs=",
 			"dev": true,
 			"requires": {
-				"@marionebl/sander": "0.6.1",
-				"load-json-file": "4.0.0"
+				"@marionebl/sander": "^0.6.1",
+				"load-json-file": "^4.0.0"
 			}
 		},
 		"@patternplate/load-meta": {
@@ -751,12 +751,12 @@
 			"integrity": "sha1-DWVWcPey9pBFq5mPeqzSwun05Cs=",
 			"dev": true,
 			"requires": {
-				"@marionebl/sander": "0.6.1",
-				"@patternplate/load-doc": "2.5.2",
-				"@patternplate/load-manifest": "2.5.2",
-				"globby": "6.1.0",
-				"load-source-map": "1.0.0",
-				"p-filter": "1.0.0"
+				"@marionebl/sander": "^0.6.1",
+				"@patternplate/load-doc": "^2.5.2",
+				"@patternplate/load-manifest": "^2.5.2",
+				"globby": "^6.1.0",
+				"load-source-map": "^1.0.0",
+				"p-filter": "^1.0.0"
 			},
 			"dependencies": {
 				"globby": {
@@ -765,11 +765,11 @@
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"glob": "7.1.2",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
@@ -780,9 +780,9 @@
 			"integrity": "sha1-LfhBTqFfXIEHXKXG+Z1CltaVkvU=",
 			"dev": true,
 			"requires": {
-				"@patternplate/websocket-client": "2.5.2",
-				"arson": "0.2.6",
-				"iframe-resizer": "3.6.1"
+				"@patternplate/websocket-client": "^2.5.2",
+				"arson": "^0.2.6",
+				"iframe-resizer": "^3.5.16"
 			}
 		},
 		"@patternplate/render-default": {
@@ -791,7 +791,7 @@
 			"integrity": "sha1-VhXVQ/Pholfzf0RAyObPGpwKsFk=",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.10"
+				"lodash": "^4.17.5"
 			},
 			"dependencies": {
 				"lodash": {
@@ -808,10 +808,10 @@
 			"integrity": "sha1-wvKxGvgL8O6A1fwibZgc79uxMXk=",
 			"dev": true,
 			"requires": {
-				"@patternplate/render-default": "2.5.2",
-				"lodash": "4.17.10",
-				"react": "16.3.2",
-				"react-dom": "16.3.2"
+				"@patternplate/render-default": "^2.5.2",
+				"lodash": "^4.17.5",
+				"react": "^16.2.0",
+				"react-dom": "^16.2.0"
 			},
 			"dependencies": {
 				"lodash": {
@@ -826,10 +826,10 @@
 					"integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
 					"dev": true,
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1",
-						"prop-types": "15.6.0"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1",
+						"prop-types": "^15.6.0"
 					}
 				},
 				"react-dom": {
@@ -838,10 +838,10 @@
 					"integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
 					"dev": true,
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1",
-						"prop-types": "15.6.0"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1",
+						"prop-types": "^15.6.0"
 					}
 				}
 			}
@@ -852,11 +852,11 @@
 			"integrity": "sha1-7ER5tUsRvtihXbCf4HH8HdpCQHs=",
 			"dev": true,
 			"requires": {
-				"@patternplate/render-react": "2.5.2",
-				"lodash": "4.17.10",
-				"react": "16.3.2",
-				"react-dom": "16.3.2",
-				"styled-components": "3.2.6"
+				"@patternplate/render-react": "^2.5.2",
+				"lodash": "^4.17.5",
+				"react": "^16.2.0",
+				"react-dom": "^16.2.0",
+				"styled-components": "^3.1.6"
 			},
 			"dependencies": {
 				"hoist-non-react-statics": {
@@ -877,10 +877,10 @@
 					"integrity": "sha512-o5GPdkhciQ3cEph6qgvYB7LTOHw/GB0qRI6ZFNugj49qJCFfgHwVNjZ5u+b7nif4vOeMIOuYj3CeYe2IBD74lg==",
 					"dev": true,
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1",
-						"prop-types": "15.6.0"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1",
+						"prop-types": "^15.6.0"
 					}
 				},
 				"react-dom": {
@@ -889,10 +889,10 @@
 					"integrity": "sha512-MMPko3zYncNrz/7gG17wJWUREZDvskZHXOwbttzl0F0L3wDmToyuETuo/r8Y5yvDejwYcRyWI1lvVBjLJWFwKA==",
 					"dev": true,
 					"requires": {
-						"fbjs": "0.8.16",
-						"loose-envify": "1.3.1",
-						"object-assign": "4.1.1",
-						"prop-types": "15.6.0"
+						"fbjs": "^0.8.16",
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.1",
+						"prop-types": "^15.6.0"
 					}
 				},
 				"styled-components": {
@@ -901,16 +901,16 @@
 					"integrity": "sha1-mebnWnRr3t0pWhfgPdFJMFWhzDs=",
 					"dev": true,
 					"requires": {
-						"buffer": "5.0.8",
-						"css-to-react-native": "2.0.4",
-						"fbjs": "0.8.16",
-						"hoist-non-react-statics": "2.5.0",
-						"is-plain-object": "2.0.4",
-						"prop-types": "15.6.0",
-						"react-is": "16.3.2",
-						"stylis": "3.5.0",
-						"stylis-rule-sheet": "0.0.10",
-						"supports-color": "3.2.3"
+						"buffer": "^5.0.3",
+						"css-to-react-native": "^2.0.3",
+						"fbjs": "^0.8.16",
+						"hoist-non-react-statics": "^2.5.0",
+						"is-plain-object": "^2.0.1",
+						"prop-types": "^15.5.4",
+						"react-is": "^16.3.1",
+						"stylis": "^3.5.0",
+						"stylis-rule-sheet": "^0.0.10",
+						"supports-color": "^3.2.3"
 					}
 				},
 				"stylis": {
@@ -925,7 +925,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -936,7 +936,7 @@
 			"integrity": "sha1-f9l6+cvF1miclvfUuMwid3kr0lI=",
 			"dev": true,
 			"requires": {
-				"@webpack-contrib/schema-utils": "1.0.0-beta.0"
+				"@webpack-contrib/schema-utils": "^1.0.0-beta.0"
 			}
 		},
 		"@patternplate/webpack-entry": {
@@ -945,13 +945,13 @@
 			"integrity": "sha1-b8KMiJ5U1cb9bLP5wa0weNHFN5k=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "3.1.0",
-				"globby": "6.1.0",
-				"loader-utils": "1.1.0",
-				"path-exists": "3.0.0",
-				"raw-loader": "0.5.1",
-				"require-from-string": "2.0.1",
-				"resolve-from": "4.0.0"
+				"glob-parent": "^3.1.0",
+				"globby": "^6.1.0",
+				"loader-utils": "^1.1.0",
+				"path-exists": "^3.0.0",
+				"raw-loader": "^0.5.1",
+				"require-from-string": "^2.0.1",
+				"resolve-from": "^4.0.0"
 			},
 			"dependencies": {
 				"globby": {
@@ -960,11 +960,11 @@
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"glob": "7.1.2",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
@@ -993,7 +993,7 @@
 			"integrity": "sha512-dP4vEDEH4rL+uUl6f//c6mjepTVdJ6Ldx3z0dZbw047T5Z+o2PZDW/Qd+I4PkTmIgk7YNAZC/TFnm3IHT5UAhw==",
 			"dev": true,
 			"requires": {
-				"@types/react": "15.6.1"
+				"@types/react": "^15"
 			}
 		},
 		"@webassemblyjs/ast": {
@@ -1004,7 +1004,7 @@
 			"requires": {
 				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
 				"@webassemblyjs/wast-parser": "1.4.3",
-				"debug": "3.1.0",
+				"debug": "^3.1.0",
 				"webassemblyjs": "1.4.3"
 			}
 		},
@@ -1020,7 +1020,7 @@
 			"integrity": "sha512-e8+KZHh+RV8MUvoSRtuT1sFXskFnWG9vbDy47Oa166xX+l0dD5sERJ21g5/tcH8Yo95e9IN3u7Jc3NbhnUcSkw==",
 			"dev": true,
 			"requires": {
-				"debug": "3.1.0"
+				"debug": "^3.1.0"
 			}
 		},
 		"@webassemblyjs/helper-code-frame": {
@@ -1054,7 +1054,7 @@
 				"@webassemblyjs/helper-buffer": "1.4.3",
 				"@webassemblyjs/helper-wasm-bytecode": "1.4.3",
 				"@webassemblyjs/wasm-gen": "1.4.3",
-				"debug": "3.1.0"
+				"debug": "^3.1.0"
 			}
 		},
 		"@webassemblyjs/leb128": {
@@ -1063,7 +1063,7 @@
 			"integrity": "sha512-4u0LJLSPzuRDWHwdqsrThYn+WqMFVqbI2ltNrHvZZkzFPO8XOZ0HFQ5eVc4jY/TNHgXcnwrHjONhPGYuuf//KQ==",
 			"dev": true,
 			"requires": {
-				"leb": "0.3.0"
+				"leb": "^0.3.0"
 			}
 		},
 		"@webassemblyjs/validation": {
@@ -1089,7 +1089,7 @@
 				"@webassemblyjs/wasm-opt": "1.4.3",
 				"@webassemblyjs/wasm-parser": "1.4.3",
 				"@webassemblyjs/wast-printer": "1.4.3",
-				"debug": "3.1.0"
+				"debug": "^3.1.0"
 			}
 		},
 		"@webassemblyjs/wasm-gen": {
@@ -1113,7 +1113,7 @@
 				"@webassemblyjs/helper-buffer": "1.4.3",
 				"@webassemblyjs/wasm-gen": "1.4.3",
 				"@webassemblyjs/wasm-parser": "1.4.3",
-				"debug": "3.1.0"
+				"debug": "^3.1.0"
 			}
 		},
 		"@webassemblyjs/wasm-parser": {
@@ -1139,7 +1139,7 @@
 				"@webassemblyjs/floating-point-hex-parser": "1.4.3",
 				"@webassemblyjs/helper-code-frame": "1.4.3",
 				"@webassemblyjs/helper-fsm": "1.4.3",
-				"long": "3.2.0",
+				"long": "^3.2.0",
 				"webassemblyjs": "1.4.3"
 			}
 		},
@@ -1151,7 +1151,7 @@
 			"requires": {
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/wast-parser": "1.4.3",
-				"long": "3.2.0"
+				"long": "^3.2.0"
 			}
 		},
 		"@webpack-contrib/schema-utils": {
@@ -1160,12 +1160,12 @@
 			"integrity": "sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==",
 			"dev": true,
 			"requires": {
-				"ajv": "6.5.0",
-				"ajv-keywords": "3.2.0",
-				"chalk": "2.4.1",
-				"strip-ansi": "4.0.0",
-				"text-table": "0.2.0",
-				"webpack-log": "1.2.0"
+				"ajv": "^6.1.0",
+				"ajv-keywords": "^3.1.0",
+				"chalk": "^2.3.2",
+				"strip-ansi": "^4.0.0",
+				"text-table": "^0.2.0",
+				"webpack-log": "^1.1.2"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -1180,7 +1180,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -1189,9 +1189,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -1206,7 +1206,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -1215,7 +1215,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -1226,8 +1226,8 @@
 			"integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
 			"dev": true,
 			"requires": {
-				"jsonparse": "1.3.1",
-				"through": "2.3.8"
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
 			}
 		},
 		"accepts": {
@@ -1236,7 +1236,7 @@
 			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
 			"dev": true,
 			"requires": {
-				"mime-types": "2.1.18",
+				"mime-types": "~2.1.18",
 				"negotiator": "0.6.1"
 			}
 		},
@@ -1252,7 +1252,7 @@
 			"integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.5.3"
+				"acorn": "^5.0.0"
 			}
 		},
 		"acorn-jsx": {
@@ -1261,7 +1261,7 @@
 			"integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.5.3"
+				"acorn": "^5.0.3"
 			}
 		},
 		"aggregate-error": {
@@ -1270,8 +1270,8 @@
 			"integrity": "sha1-iINE2tAiCnLjr1CQYRf0h3GSX6w=",
 			"dev": true,
 			"requires": {
-				"clean-stack": "1.3.0",
-				"indent-string": "3.2.0"
+				"clean-stack": "^1.0.0",
+				"indent-string": "^3.0.0"
 			}
 		},
 		"ajv": {
@@ -1280,10 +1280,10 @@
 			"integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
 			"dev": true,
 			"requires": {
-				"fast-deep-equal": "2.0.1",
-				"fast-json-stable-stringify": "2.0.0",
-				"json-schema-traverse": "0.3.1",
-				"uri-js": "4.2.1"
+				"fast-deep-equal": "^2.0.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.3.0",
+				"uri-js": "^4.2.1"
 			}
 		},
 		"ajv-keywords": {
@@ -1322,8 +1322,8 @@
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"dev": true,
 			"requires": {
-				"micromatch": "3.1.10",
-				"normalize-path": "2.1.1"
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
 			}
 		},
 		"aproba": {
@@ -1338,7 +1338,7 @@
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"arr-diff": {
@@ -1389,7 +1389,7 @@
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "1.0.3"
+				"array-uniq": "^1.0.1"
 			}
 		},
 		"array-uniq": {
@@ -1427,9 +1427,9 @@
 			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.1"
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"assert": {
@@ -1477,12 +1477,12 @@
 			"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
 			"dev": true,
 			"requires": {
-				"browserslist": "1.7.7",
-				"caniuse-db": "1.0.30000845",
-				"normalize-range": "0.1.2",
-				"num2fraction": "1.2.2",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"browserslist": "^1.7.6",
+				"caniuse-db": "^1.0.30000634",
+				"normalize-range": "^0.1.2",
+				"num2fraction": "^1.2.2",
+				"postcss": "^5.2.16",
+				"postcss-value-parser": "^3.2.3"
 			}
 		},
 		"babel-code-frame": {
@@ -1491,9 +1491,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			}
 		},
 		"babel-polyfill": {
@@ -1502,9 +1502,9 @@
 			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.1",
-				"regenerator-runtime": "0.10.5"
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"regenerator-runtime": "^0.10.5"
 			},
 			"dependencies": {
 				"regenerator-runtime": {
@@ -1521,8 +1521,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "2.5.1",
-				"regenerator-runtime": "0.11.0"
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
 			}
 		},
 		"bail": {
@@ -1543,13 +1543,13 @@
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
-				"cache-base": "1.0.1",
-				"class-utils": "0.3.6",
-				"component-emitter": "1.2.1",
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"mixin-deep": "1.3.1",
-				"pascalcase": "0.1.1"
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1558,7 +1558,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -1567,7 +1567,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -1576,7 +1576,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -1585,9 +1585,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				}
 			}
@@ -1628,15 +1628,15 @@
 			"dev": true,
 			"requires": {
 				"bytes": "3.0.0",
-				"content-type": "1.0.4",
+				"content-type": "~1.0.4",
 				"debug": "2.6.9",
-				"depd": "1.1.2",
-				"http-errors": "1.6.3",
+				"depd": "~1.1.1",
+				"http-errors": "~1.6.2",
 				"iconv-lite": "0.4.19",
-				"on-finished": "2.3.0",
+				"on-finished": "~2.3.0",
 				"qs": "6.5.1",
 				"raw-body": "2.3.2",
-				"type-is": "1.6.16"
+				"type-is": "~1.6.15"
 			},
 			"dependencies": {
 				"debug": {
@@ -1656,7 +1656,7 @@
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -1666,16 +1666,16 @@
 			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "1.1.0",
-				"array-unique": "0.3.2",
-				"extend-shallow": "2.0.1",
-				"fill-range": "4.0.0",
-				"isobject": "3.0.1",
-				"repeat-element": "1.1.2",
-				"snapdragon": "0.8.2",
-				"snapdragon-node": "2.1.1",
-				"split-string": "3.1.0",
-				"to-regex": "3.0.2"
+				"arr-flatten": "^1.1.0",
+				"array-unique": "^0.3.2",
+				"extend-shallow": "^2.0.1",
+				"fill-range": "^4.0.0",
+				"isobject": "^3.0.1",
+				"repeat-element": "^1.1.2",
+				"snapdragon": "^0.8.1",
+				"snapdragon-node": "^2.0.1",
+				"split-string": "^3.0.2",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -1684,7 +1684,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -1701,12 +1701,12 @@
 			"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 			"dev": true,
 			"requires": {
-				"buffer-xor": "1.0.3",
-				"cipher-base": "1.0.4",
-				"create-hash": "1.2.0",
-				"evp_bytestokey": "1.0.3",
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"buffer-xor": "^1.0.3",
+				"cipher-base": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.3",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"browserify-cipher": {
@@ -1715,9 +1715,9 @@
 			"integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
 			"dev": true,
 			"requires": {
-				"browserify-aes": "1.2.0",
-				"browserify-des": "1.0.1",
-				"evp_bytestokey": "1.0.3"
+				"browserify-aes": "^1.0.4",
+				"browserify-des": "^1.0.0",
+				"evp_bytestokey": "^1.0.0"
 			}
 		},
 		"browserify-des": {
@@ -1726,9 +1726,9 @@
 			"integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"des.js": "1.0.0",
-				"inherits": "2.0.3"
+				"cipher-base": "^1.0.1",
+				"des.js": "^1.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"browserify-rsa": {
@@ -1737,8 +1737,8 @@
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"randombytes": "2.0.6"
+				"bn.js": "^4.1.0",
+				"randombytes": "^2.0.1"
 			}
 		},
 		"browserify-sign": {
@@ -1747,13 +1747,13 @@
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.2.0",
-				"create-hmac": "1.1.7",
-				"elliptic": "6.4.0",
-				"inherits": "2.0.3",
-				"parse-asn1": "5.1.1"
+				"bn.js": "^4.1.1",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.2",
+				"elliptic": "^6.0.0",
+				"inherits": "^2.0.1",
+				"parse-asn1": "^5.0.0"
 			}
 		},
 		"browserify-zlib": {
@@ -1762,7 +1762,7 @@
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"dev": true,
 			"requires": {
-				"pako": "1.0.6"
+				"pako": "~1.0.5"
 			}
 		},
 		"browserslist": {
@@ -1771,8 +1771,8 @@
 			"integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
 			"dev": true,
 			"requires": {
-				"caniuse-db": "1.0.30000845",
-				"electron-to-chromium": "1.3.47"
+				"caniuse-db": "^1.0.30000639",
+				"electron-to-chromium": "^1.2.7"
 			}
 		},
 		"buble": {
@@ -1781,14 +1781,14 @@
 			"integrity": "sha512-3B0Lcy2u6x6km0BqTz/FS3UnrOJlnIlBWsyjvtqzdtmWkqiS0+Sg4hc6L9Mmm63hZKTACpYS9vUeIoKSi1vcrQ==",
 			"dev": true,
 			"requires": {
-				"acorn": "5.5.3",
-				"acorn-dynamic-import": "3.0.0",
-				"acorn-jsx": "4.1.1",
-				"chalk": "2.4.1",
-				"magic-string": "0.22.5",
-				"minimist": "1.2.0",
-				"os-homedir": "1.0.2",
-				"vlq": "1.0.0"
+				"acorn": "^5.4.1",
+				"acorn-dynamic-import": "^3.0.0",
+				"acorn-jsx": "^4.1.1",
+				"chalk": "^2.3.1",
+				"magic-string": "^0.22.4",
+				"minimist": "^1.2.0",
+				"os-homedir": "^1.0.1",
+				"vlq": "^1.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -1797,7 +1797,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -1806,9 +1806,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -1823,7 +1823,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -1833,8 +1833,8 @@
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.8.tgz",
 			"integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==",
 			"requires": {
-				"base64-js": "1.2.1",
-				"ieee754": "1.1.8"
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4"
 			}
 		},
 		"buffer-from": {
@@ -1873,19 +1873,19 @@
 			"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
 			"dev": true,
 			"requires": {
-				"bluebird": "3.5.1",
-				"chownr": "1.0.1",
-				"glob": "7.1.2",
-				"graceful-fs": "4.1.11",
-				"lru-cache": "4.1.1",
-				"mississippi": "2.0.0",
-				"mkdirp": "0.5.1",
-				"move-concurrently": "1.0.1",
-				"promise-inflight": "1.0.1",
-				"rimraf": "2.6.2",
-				"ssri": "5.3.0",
-				"unique-filename": "1.1.0",
-				"y18n": "4.0.0"
+				"bluebird": "^3.5.1",
+				"chownr": "^1.0.1",
+				"glob": "^7.1.2",
+				"graceful-fs": "^4.1.11",
+				"lru-cache": "^4.1.1",
+				"mississippi": "^2.0.0",
+				"mkdirp": "^0.5.1",
+				"move-concurrently": "^1.0.1",
+				"promise-inflight": "^1.0.1",
+				"rimraf": "^2.6.2",
+				"ssri": "^5.2.4",
+				"unique-filename": "^1.1.0",
+				"y18n": "^4.0.0"
 			}
 		},
 		"cache-base": {
@@ -1894,15 +1894,15 @@
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
-				"collection-visit": "1.0.0",
-				"component-emitter": "1.2.1",
-				"get-value": "2.0.6",
-				"has-value": "1.0.0",
-				"isobject": "3.0.1",
-				"set-value": "2.0.0",
-				"to-object-path": "0.3.0",
-				"union-value": "1.0.0",
-				"unset-value": "1.0.0"
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
 			}
 		},
 		"call-me-maybe": {
@@ -1917,7 +1917,7 @@
 			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
 			"dev": true,
 			"requires": {
-				"callsites": "2.0.0"
+				"callsites": "^2.0.0"
 			}
 		},
 		"caller-path": {
@@ -1926,7 +1926,7 @@
 			"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
 			"dev": true,
 			"requires": {
-				"caller-callsite": "2.0.0"
+				"caller-callsite": "^2.0.0"
 			}
 		},
 		"callsites": {
@@ -1941,8 +1941,8 @@
 			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
 			"dev": true,
 			"requires": {
-				"no-case": "2.3.2",
-				"upper-case": "1.1.3"
+				"no-case": "^2.2.0",
+				"upper-case": "^1.1.1"
 			}
 		},
 		"camelcase": {
@@ -1957,8 +1957,8 @@
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "2.1.1",
-				"map-obj": "1.0.1"
+				"camelcase": "^2.0.0",
+				"map-obj": "^1.0.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -1975,10 +1975,10 @@
 			"integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
 			"dev": true,
 			"requires": {
-				"browserslist": "1.7.7",
-				"caniuse-db": "1.0.30000845",
-				"lodash.memoize": "4.1.2",
-				"lodash.uniq": "4.5.0"
+				"browserslist": "^1.3.6",
+				"caniuse-db": "^1.0.30000529",
+				"lodash.memoize": "^4.1.2",
+				"lodash.uniq": "^4.5.0"
 			}
 		},
 		"caniuse-db": {
@@ -1999,11 +1999,11 @@
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "2.2.1",
-				"escape-string-regexp": "1.0.5",
-				"has-ansi": "2.0.0",
-				"strip-ansi": "3.0.1",
-				"supports-color": "2.0.0"
+				"ansi-styles": "^2.2.1",
+				"escape-string-regexp": "^1.0.2",
+				"has-ansi": "^2.0.0",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^2.0.0"
 			}
 		},
 		"character-entities": {
@@ -2036,15 +2036,15 @@
 			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
 			"dev": true,
 			"requires": {
-				"anymatch": "1.3.2",
-				"async-each": "1.0.1",
-				"fsevents": "1.2.4",
-				"glob-parent": "2.0.0",
-				"inherits": "2.0.3",
-				"is-binary-path": "1.0.1",
-				"is-glob": "2.0.1",
-				"path-is-absolute": "1.0.1",
-				"readdirp": "2.1.0"
+				"anymatch": "^1.3.0",
+				"async-each": "^1.0.0",
+				"fsevents": "^1.0.0",
+				"glob-parent": "^2.0.0",
+				"inherits": "^2.0.1",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^2.0.0",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.0.0"
 			},
 			"dependencies": {
 				"anymatch": {
@@ -2053,8 +2053,8 @@
 					"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
 					"dev": true,
 					"requires": {
-						"micromatch": "2.3.11",
-						"normalize-path": "2.1.1"
+						"micromatch": "^2.1.5",
+						"normalize-path": "^2.0.0"
 					}
 				},
 				"arr-diff": {
@@ -2063,7 +2063,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "1.1.0"
+						"arr-flatten": "^1.0.1"
 					}
 				},
 				"array-unique": {
@@ -2078,9 +2078,9 @@
 					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 					"dev": true,
 					"requires": {
-						"expand-range": "1.8.2",
-						"preserve": "0.2.0",
-						"repeat-element": "1.1.2"
+						"expand-range": "^1.8.1",
+						"preserve": "^0.2.0",
+						"repeat-element": "^1.1.2"
 					}
 				},
 				"expand-brackets": {
@@ -2089,7 +2089,7 @@
 					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 					"dev": true,
 					"requires": {
-						"is-posix-bracket": "0.1.1"
+						"is-posix-bracket": "^0.1.0"
 					}
 				},
 				"extglob": {
@@ -2098,7 +2098,7 @@
 					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"glob-parent": {
@@ -2107,7 +2107,7 @@
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 					"dev": true,
 					"requires": {
-						"is-glob": "2.0.1"
+						"is-glob": "^2.0.0"
 					}
 				},
 				"is-extglob": {
@@ -2122,7 +2122,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				},
 				"kind-of": {
@@ -2131,7 +2131,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				},
 				"micromatch": {
@@ -2140,19 +2140,19 @@
 					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 					"dev": true,
 					"requires": {
-						"arr-diff": "2.0.0",
-						"array-unique": "0.2.1",
-						"braces": "1.8.5",
-						"expand-brackets": "0.1.5",
-						"extglob": "0.3.2",
-						"filename-regex": "2.0.1",
-						"is-extglob": "1.0.0",
-						"is-glob": "2.0.1",
-						"kind-of": "3.2.2",
-						"normalize-path": "2.1.1",
-						"object.omit": "2.0.1",
-						"parse-glob": "3.0.4",
-						"regex-cache": "0.4.4"
+						"arr-diff": "^2.0.0",
+						"array-unique": "^0.2.1",
+						"braces": "^1.8.2",
+						"expand-brackets": "^0.1.4",
+						"extglob": "^0.3.1",
+						"filename-regex": "^2.0.0",
+						"is-extglob": "^1.0.0",
+						"is-glob": "^2.0.1",
+						"kind-of": "^3.0.2",
+						"normalize-path": "^2.0.1",
+						"object.omit": "^2.0.0",
+						"parse-glob": "^3.0.4",
+						"regex-cache": "^0.4.2"
 					}
 				}
 			}
@@ -2181,8 +2181,8 @@
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"clap": {
@@ -2191,7 +2191,7 @@
 			"integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3"
+				"chalk": "^1.1.3"
 			}
 		},
 		"class-utils": {
@@ -2200,10 +2200,10 @@
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "3.1.0",
-				"define-property": "0.2.5",
-				"isobject": "3.0.1",
-				"static-extend": "0.1.2"
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -2212,7 +2212,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
@@ -2223,7 +2223,7 @@
 			"integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
 			"dev": true,
 			"requires": {
-				"source-map": "0.5.7"
+				"source-map": "0.5.x"
 			}
 		},
 		"clean-stack": {
@@ -2238,7 +2238,7 @@
 			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "1.0.1"
+				"restore-cursor": "^1.0.1"
 			}
 		},
 		"cli-spinners": {
@@ -2265,7 +2265,7 @@
 			"integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
 			"dev": true,
 			"requires": {
-				"q": "1.5.1"
+				"q": "^1.1.2"
 			}
 		},
 		"code-point-at": {
@@ -2286,8 +2286,8 @@
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
-				"map-visit": "1.0.0",
-				"object-visit": "1.0.1"
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
 			}
 		},
 		"color": {
@@ -2296,9 +2296,9 @@
 			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
 			"dev": true,
 			"requires": {
-				"clone": "1.0.4",
-				"color-convert": "1.9.1",
-				"color-string": "0.3.0"
+				"clone": "^1.0.2",
+				"color-convert": "^1.3.0",
+				"color-string": "^0.3.0"
 			}
 		},
 		"color-convert": {
@@ -2307,7 +2307,7 @@
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.1.1"
 			}
 		},
 		"color-name": {
@@ -2322,7 +2322,7 @@
 			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
 			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.0.0"
 			}
 		},
 		"colormin": {
@@ -2331,9 +2331,9 @@
 			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
 			"dev": true,
 			"requires": {
-				"color": "0.11.4",
+				"color": "^0.11.0",
 				"css-color-names": "0.0.4",
-				"has": "1.0.1"
+				"has": "^1.0.1"
 			}
 		},
 		"colors": {
@@ -2360,7 +2360,7 @@
 			"integrity": "sha1-T9hyCF68XyYtnMI7D/NLPkV2d/A=",
 			"dev": true,
 			"requires": {
-				"common-sequence": "1.0.2"
+				"common-sequence": "^1.0.2"
 			}
 		},
 		"common-sequence": {
@@ -2381,8 +2381,8 @@
 			"integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
 			"dev": true,
 			"requires": {
-				"array-ify": "1.0.0",
-				"dot-prop": "3.0.0"
+				"array-ify": "^1.0.0",
+				"dot-prop": "^3.0.0"
 			}
 		},
 		"component-emitter": {
@@ -2403,10 +2403,10 @@
 			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "1.0.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"typedarray": "0.0.6"
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
 			}
 		},
 		"concurrently": {
@@ -2417,12 +2417,12 @@
 			"requires": {
 				"chalk": "0.5.1",
 				"commander": "2.6.0",
-				"date-fns": "1.29.0",
-				"lodash": "4.17.4",
+				"date-fns": "^1.23.0",
+				"lodash": "^4.5.1",
 				"rx": "2.3.24",
-				"spawn-command": "0.0.2-1",
-				"supports-color": "3.2.3",
-				"tree-kill": "1.2.0"
+				"spawn-command": "^0.0.2-1",
+				"supports-color": "^3.2.3",
+				"tree-kill": "^1.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -2443,11 +2443,11 @@
 					"integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "1.1.0",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "0.1.0",
-						"strip-ansi": "0.3.0",
-						"supports-color": "0.2.0"
+						"ansi-styles": "^1.1.0",
+						"escape-string-regexp": "^1.0.0",
+						"has-ansi": "^0.1.0",
+						"strip-ansi": "^0.3.0",
+						"supports-color": "^0.2.0"
 					},
 					"dependencies": {
 						"supports-color": {
@@ -2470,7 +2470,7 @@
 					"integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "0.2.1"
+						"ansi-regex": "^0.2.0"
 					}
 				},
 				"strip-ansi": {
@@ -2479,7 +2479,7 @@
 					"integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "0.2.1"
+						"ansi-regex": "^0.2.1"
 					}
 				},
 				"supports-color": {
@@ -2488,7 +2488,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -2499,7 +2499,7 @@
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
 			"dev": true,
 			"requires": {
-				"date-now": "0.1.4"
+				"date-now": "^0.1.4"
 			}
 		},
 		"constants-browserify": {
@@ -2538,12 +2538,12 @@
 			"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
 			"dev": true,
 			"requires": {
-				"aproba": "1.2.0",
-				"fs-write-stream-atomic": "1.0.10",
-				"iferr": "0.1.5",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2",
-				"run-queue": "1.0.3"
+				"aproba": "^1.1.1",
+				"fs-write-stream-atomic": "^1.0.8",
+				"iferr": "^0.1.5",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4",
+				"run-queue": "^1.0.0"
 			}
 		},
 		"copy-descriptor": {
@@ -2570,8 +2570,8 @@
 			"integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
 			"dev": true,
 			"requires": {
-				"object-assign": "4.1.1",
-				"vary": "1.1.2"
+				"object-assign": "^4",
+				"vary": "^1"
 			}
 		},
 		"cosmiconfig": {
@@ -2580,10 +2580,10 @@
 			"integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
 			"dev": true,
 			"requires": {
-				"is-directory": "0.3.1",
-				"js-yaml": "3.10.0",
-				"parse-json": "3.0.0",
-				"require-from-string": "2.0.1"
+				"is-directory": "^0.3.1",
+				"js-yaml": "^3.9.0",
+				"parse-json": "^3.0.0",
+				"require-from-string": "^2.0.1"
 			},
 			"dependencies": {
 				"parse-json": {
@@ -2592,7 +2592,7 @@
 					"integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.1"
+						"error-ex": "^1.3.1"
 					}
 				}
 			}
@@ -2603,8 +2603,8 @@
 			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"elliptic": "6.4.0"
+				"bn.js": "^4.1.0",
+				"elliptic": "^6.0.0"
 			}
 		},
 		"create-hash": {
@@ -2613,11 +2613,11 @@
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"inherits": "2.0.3",
-				"md5.js": "1.3.4",
-				"ripemd160": "2.0.2",
-				"sha.js": "2.4.11"
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"md5.js": "^1.3.4",
+				"ripemd160": "^2.0.1",
+				"sha.js": "^2.4.0"
 			}
 		},
 		"create-hmac": {
@@ -2626,12 +2626,12 @@
 			"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"create-hash": "1.2.0",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.2",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.11"
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"create-react-class": {
@@ -2639,9 +2639,9 @@
 			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
 			"integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1"
+				"fbjs": "^0.8.9",
+				"loose-envify": "^1.3.1",
+				"object-assign": "^4.1.1"
 			}
 		},
 		"cross-spawn": {
@@ -2650,9 +2650,9 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "4.1.1",
-				"shebang-command": "1.2.0",
-				"which": "1.3.0"
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"crypto-browserify": {
@@ -2661,17 +2661,17 @@
 			"integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
 			"dev": true,
 			"requires": {
-				"browserify-cipher": "1.0.1",
-				"browserify-sign": "4.0.4",
-				"create-ecdh": "4.0.3",
-				"create-hash": "1.2.0",
-				"create-hmac": "1.1.7",
-				"diffie-hellman": "5.0.3",
-				"inherits": "2.0.3",
-				"pbkdf2": "3.0.16",
-				"public-encrypt": "4.0.2",
-				"randombytes": "2.0.6",
-				"randomfill": "1.0.4"
+				"browserify-cipher": "^1.0.0",
+				"browserify-sign": "^4.0.0",
+				"create-ecdh": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.0",
+				"diffie-hellman": "^5.0.0",
+				"inherits": "^2.0.1",
+				"pbkdf2": "^3.0.3",
+				"public-encrypt": "^4.0.0",
+				"randombytes": "^2.0.0",
+				"randomfill": "^1.0.3"
 			}
 		},
 		"css-color-keywords": {
@@ -2691,20 +2691,20 @@
 			"integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"css-selector-tokenizer": "0.7.0",
-				"cssnano": "3.10.0",
-				"icss-utils": "2.1.0",
-				"loader-utils": "1.1.0",
-				"lodash.camelcase": "4.3.0",
-				"object-assign": "4.1.1",
-				"postcss": "5.2.18",
-				"postcss-modules-extract-imports": "1.2.0",
-				"postcss-modules-local-by-default": "1.2.0",
-				"postcss-modules-scope": "1.1.0",
-				"postcss-modules-values": "1.3.0",
-				"postcss-value-parser": "3.3.0",
-				"source-list-map": "2.0.0"
+				"babel-code-frame": "^6.26.0",
+				"css-selector-tokenizer": "^0.7.0",
+				"cssnano": "^3.10.0",
+				"icss-utils": "^2.1.0",
+				"loader-utils": "^1.0.2",
+				"lodash.camelcase": "^4.3.0",
+				"object-assign": "^4.1.1",
+				"postcss": "^5.0.6",
+				"postcss-modules-extract-imports": "^1.2.0",
+				"postcss-modules-local-by-default": "^1.2.0",
+				"postcss-modules-scope": "^1.1.0",
+				"postcss-modules-values": "^1.3.0",
+				"postcss-value-parser": "^3.3.0",
+				"source-list-map": "^2.0.0"
 			}
 		},
 		"css-selector-tokenizer": {
@@ -2713,9 +2713,9 @@
 			"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
 			"dev": true,
 			"requires": {
-				"cssesc": "0.1.0",
-				"fastparse": "1.1.1",
-				"regexpu-core": "1.0.0"
+				"cssesc": "^0.1.0",
+				"fastparse": "^1.1.1",
+				"regexpu-core": "^1.0.0"
 			}
 		},
 		"css-to-react-native": {
@@ -2723,9 +2723,9 @@
 			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.0.4.tgz",
 			"integrity": "sha1-z0zEB1WLNHTUuovhos07bOcTEBs=",
 			"requires": {
-				"css-color-keywords": "1.0.0",
-				"fbjs": "0.8.16",
-				"postcss-value-parser": "3.3.0"
+				"css-color-keywords": "^1.0.0",
+				"fbjs": "^0.8.5",
+				"postcss-value-parser": "^3.3.0"
 			}
 		},
 		"cssesc": {
@@ -2740,38 +2740,38 @@
 			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
 			"dev": true,
 			"requires": {
-				"autoprefixer": "6.7.7",
-				"decamelize": "1.2.0",
-				"defined": "1.0.0",
-				"has": "1.0.1",
-				"object-assign": "4.1.1",
-				"postcss": "5.2.18",
-				"postcss-calc": "5.3.1",
-				"postcss-colormin": "2.2.2",
-				"postcss-convert-values": "2.6.1",
-				"postcss-discard-comments": "2.0.4",
-				"postcss-discard-duplicates": "2.1.0",
-				"postcss-discard-empty": "2.1.0",
-				"postcss-discard-overridden": "0.1.1",
-				"postcss-discard-unused": "2.2.3",
-				"postcss-filter-plugins": "2.0.2",
-				"postcss-merge-idents": "2.1.7",
-				"postcss-merge-longhand": "2.0.2",
-				"postcss-merge-rules": "2.1.2",
-				"postcss-minify-font-values": "1.0.5",
-				"postcss-minify-gradients": "1.0.5",
-				"postcss-minify-params": "1.2.2",
-				"postcss-minify-selectors": "2.1.1",
-				"postcss-normalize-charset": "1.1.1",
-				"postcss-normalize-url": "3.0.8",
-				"postcss-ordered-values": "2.2.3",
-				"postcss-reduce-idents": "2.4.0",
-				"postcss-reduce-initial": "1.0.1",
-				"postcss-reduce-transforms": "1.0.4",
-				"postcss-svgo": "2.1.6",
-				"postcss-unique-selectors": "2.0.2",
-				"postcss-value-parser": "3.3.0",
-				"postcss-zindex": "2.2.0"
+				"autoprefixer": "^6.3.1",
+				"decamelize": "^1.1.2",
+				"defined": "^1.0.0",
+				"has": "^1.0.1",
+				"object-assign": "^4.0.1",
+				"postcss": "^5.0.14",
+				"postcss-calc": "^5.2.0",
+				"postcss-colormin": "^2.1.8",
+				"postcss-convert-values": "^2.3.4",
+				"postcss-discard-comments": "^2.0.4",
+				"postcss-discard-duplicates": "^2.0.1",
+				"postcss-discard-empty": "^2.0.1",
+				"postcss-discard-overridden": "^0.1.1",
+				"postcss-discard-unused": "^2.2.1",
+				"postcss-filter-plugins": "^2.0.0",
+				"postcss-merge-idents": "^2.1.5",
+				"postcss-merge-longhand": "^2.0.1",
+				"postcss-merge-rules": "^2.0.3",
+				"postcss-minify-font-values": "^1.0.2",
+				"postcss-minify-gradients": "^1.0.1",
+				"postcss-minify-params": "^1.0.4",
+				"postcss-minify-selectors": "^2.0.4",
+				"postcss-normalize-charset": "^1.1.0",
+				"postcss-normalize-url": "^3.0.7",
+				"postcss-ordered-values": "^2.1.0",
+				"postcss-reduce-idents": "^2.2.2",
+				"postcss-reduce-initial": "^1.0.0",
+				"postcss-reduce-transforms": "^1.0.3",
+				"postcss-svgo": "^2.1.1",
+				"postcss-unique-selectors": "^2.0.2",
+				"postcss-value-parser": "^3.2.3",
+				"postcss-zindex": "^2.0.1"
 			}
 		},
 		"csso": {
@@ -2780,8 +2780,8 @@
 			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
 			"dev": true,
 			"requires": {
-				"clap": "1.2.3",
-				"source-map": "0.5.7"
+				"clap": "^1.0.9",
+				"source-map": "^0.5.3"
 			}
 		},
 		"currently-unhandled": {
@@ -2790,7 +2790,7 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"dev": true,
 			"requires": {
-				"array-find-index": "1.0.2"
+				"array-find-index": "^1.0.1"
 			}
 		},
 		"cyclist": {
@@ -2805,7 +2805,7 @@
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
 			"dev": true,
 			"requires": {
-				"es5-ext": "0.10.42"
+				"es5-ext": "^0.10.9"
 			}
 		},
 		"dargs": {
@@ -2814,7 +2814,7 @@
 			"integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"date-fns": {
@@ -2856,7 +2856,7 @@
 			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 			"dev": true,
 			"requires": {
-				"clone": "1.0.4"
+				"clone": "^1.0.2"
 			}
 		},
 		"define-properties": {
@@ -2865,8 +2865,8 @@
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"dev": true,
 			"requires": {
-				"foreach": "2.0.5",
-				"object-keys": "1.0.11"
+				"foreach": "^2.0.5",
+				"object-keys": "^1.0.8"
 			}
 		},
 		"define-property": {
@@ -2875,8 +2875,8 @@
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
-				"is-descriptor": "1.0.2",
-				"isobject": "3.0.1"
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
@@ -2885,7 +2885,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -2894,7 +2894,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -2903,9 +2903,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				}
 			}
@@ -2928,8 +2928,8 @@
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.1"
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"destroy": {
@@ -2944,9 +2944,9 @@
 			"integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"miller-rabin": "4.0.1",
-				"randombytes": "2.0.6"
+				"bn.js": "^4.1.0",
+				"miller-rabin": "^4.0.0",
+				"randombytes": "^2.0.0"
 			}
 		},
 		"dir-glob": {
@@ -2955,8 +2955,8 @@
 			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"path-type": "3.0.0"
+				"arrify": "^1.0.1",
+				"path-type": "^3.0.0"
 			},
 			"dependencies": {
 				"path-type": {
@@ -2965,7 +2965,7 @@
 					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 					"dev": true,
 					"requires": {
-						"pify": "3.0.0"
+						"pify": "^3.0.0"
 					}
 				},
 				"pify": {
@@ -2988,7 +2988,7 @@
 			"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
 			"dev": true,
 			"requires": {
-				"is-obj": "1.0.1"
+				"is-obj": "^1.0.0"
 			}
 		},
 		"duplexify": {
@@ -2997,10 +2997,10 @@
 			"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "1.4.1",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"stream-shift": "1.0.0"
+				"end-of-stream": "^1.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0",
+				"stream-shift": "^1.0.0"
 			}
 		},
 		"ee-first": {
@@ -3021,13 +3021,13 @@
 			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0",
-				"hash.js": "1.1.3",
-				"hmac-drbg": "1.0.1",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.1",
-				"minimalistic-crypto-utils": "1.0.1"
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
 		"emojis-list": {
@@ -3047,7 +3047,7 @@
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 			"requires": {
-				"iconv-lite": "0.4.19"
+				"iconv-lite": "~0.4.13"
 			}
 		},
 		"end-of-stream": {
@@ -3056,7 +3056,7 @@
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0"
+				"once": "^1.4.0"
 			}
 		},
 		"enhanced-resolve": {
@@ -3065,9 +3065,9 @@
 			"integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"memory-fs": "0.4.1",
-				"tapable": "1.0.0"
+				"graceful-fs": "^4.1.2",
+				"memory-fs": "^0.4.0",
+				"tapable": "^1.0.0"
 			}
 		},
 		"errno": {
@@ -3076,7 +3076,7 @@
 			"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 			"dev": true,
 			"requires": {
-				"prr": "1.0.1"
+				"prr": "~1.0.1"
 			}
 		},
 		"error-ex": {
@@ -3085,7 +3085,7 @@
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"errorhandler": {
@@ -3094,8 +3094,8 @@
 			"integrity": "sha1-6rpkyl1UKjEayUX1gt78M2Fl2fQ=",
 			"dev": true,
 			"requires": {
-				"accepts": "1.3.5",
-				"escape-html": "1.0.3"
+				"accepts": "~1.3.3",
+				"escape-html": "~1.0.3"
 			}
 		},
 		"es5-ext": {
@@ -3104,9 +3104,9 @@
 			"integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
 			"dev": true,
 			"requires": {
-				"es6-iterator": "2.0.3",
-				"es6-symbol": "3.1.1",
-				"next-tick": "1.0.0"
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "~3.1.1",
+				"next-tick": "1"
 			}
 		},
 		"es6-iterator": {
@@ -3115,9 +3115,9 @@
 			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
 			"dev": true,
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.42",
-				"es6-symbol": "3.1.1"
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
 			}
 		},
 		"es6-symbol": {
@@ -3126,8 +3126,8 @@
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
 			"dev": true,
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.42"
+				"d": "1",
+				"es5-ext": "~0.10.14"
 			}
 		},
 		"es6-templates": {
@@ -3136,8 +3136,8 @@
 			"integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
 			"dev": true,
 			"requires": {
-				"recast": "0.11.23",
-				"through": "2.3.8"
+				"recast": "~0.11.12",
+				"through": "~2.3.6"
 			}
 		},
 		"escape-html": {
@@ -3158,8 +3158,8 @@
 			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
 			"dev": true,
 			"requires": {
-				"esrecurse": "4.2.1",
-				"estraverse": "4.2.0"
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
 			}
 		},
 		"esprima": {
@@ -3174,7 +3174,7 @@
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0"
+				"estraverse": "^4.1.0"
 			}
 		},
 		"estraverse": {
@@ -3207,8 +3207,8 @@
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
 			"dev": true,
 			"requires": {
-				"md5.js": "1.3.4",
-				"safe-buffer": "5.1.1"
+				"md5.js": "^1.3.4",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"execa": {
@@ -3217,13 +3217,13 @@
 			"integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			}
 		},
 		"exit-hook": {
@@ -3238,13 +3238,13 @@
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"posix-character-classes": "0.1.1",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
+				"debug": "^2.3.3",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"posix-character-classes": "^0.1.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
 				"debug": {
@@ -3262,7 +3262,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"extend-shallow": {
@@ -3271,7 +3271,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -3282,7 +3282,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "2.2.4"
+				"fill-range": "^2.1.0"
 			},
 			"dependencies": {
 				"fill-range": {
@@ -3291,11 +3291,11 @@
 					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
 					"dev": true,
 					"requires": {
-						"is-number": "2.1.0",
-						"isobject": "2.1.0",
-						"randomatic": "3.0.0",
-						"repeat-element": "1.1.2",
-						"repeat-string": "1.6.1"
+						"is-number": "^2.1.0",
+						"isobject": "^2.0.0",
+						"randomatic": "^3.0.0",
+						"repeat-element": "^1.1.2",
+						"repeat-string": "^1.5.2"
 					}
 				},
 				"is-number": {
@@ -3304,7 +3304,7 @@
 					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 					"dev": true,
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					}
 				},
 				"isobject": {
@@ -3322,7 +3322,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -3333,36 +3333,36 @@
 			"integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
 			"dev": true,
 			"requires": {
-				"accepts": "1.3.5",
+				"accepts": "~1.3.5",
 				"array-flatten": "1.1.1",
 				"body-parser": "1.18.2",
 				"content-disposition": "0.5.2",
-				"content-type": "1.0.4",
+				"content-type": "~1.0.4",
 				"cookie": "0.3.1",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
-				"depd": "1.1.2",
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"etag": "1.8.1",
+				"depd": "~1.1.2",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
 				"finalhandler": "1.1.1",
 				"fresh": "0.5.2",
 				"merge-descriptors": "1.0.1",
-				"methods": "1.1.2",
-				"on-finished": "2.3.0",
-				"parseurl": "1.3.2",
+				"methods": "~1.1.2",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.2",
 				"path-to-regexp": "0.1.7",
-				"proxy-addr": "2.0.3",
+				"proxy-addr": "~2.0.3",
 				"qs": "6.5.1",
-				"range-parser": "1.2.0",
+				"range-parser": "~1.2.0",
 				"safe-buffer": "5.1.1",
 				"send": "0.16.2",
 				"serve-static": "1.13.2",
 				"setprototypeof": "1.1.0",
-				"statuses": "1.4.0",
-				"type-is": "1.6.16",
+				"statuses": "~1.4.0",
+				"type-is": "~1.6.16",
 				"utils-merge": "1.0.1",
-				"vary": "1.1.2"
+				"vary": "~1.1.2"
 			},
 			"dependencies": {
 				"debug": {
@@ -3394,8 +3394,8 @@
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"dev": true,
 			"requires": {
-				"assign-symbols": "1.0.0",
-				"is-extendable": "1.0.1"
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -3404,7 +3404,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -3415,14 +3415,14 @@
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 			"dev": true,
 			"requires": {
-				"array-unique": "0.3.2",
-				"define-property": "1.0.0",
-				"expand-brackets": "2.1.4",
-				"extend-shallow": "2.0.1",
-				"fragment-cache": "0.2.1",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
+				"array-unique": "^0.3.2",
+				"define-property": "^1.0.0",
+				"expand-brackets": "^2.1.4",
+				"extend-shallow": "^2.0.1",
+				"fragment-cache": "^0.2.1",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -3431,7 +3431,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"extend-shallow": {
@@ -3440,7 +3440,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -3449,7 +3449,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -3458,7 +3458,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -3467,9 +3467,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				}
 			}
@@ -3486,12 +3486,12 @@
 			"integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
 			"dev": true,
 			"requires": {
-				"@mrmlnc/readdir-enhanced": "2.2.1",
-				"@nodelib/fs.stat": "1.0.2",
-				"glob-parent": "3.1.0",
-				"is-glob": "4.0.0",
-				"merge2": "1.2.2",
-				"micromatch": "3.1.10"
+				"@mrmlnc/readdir-enhanced": "^2.2.1",
+				"@nodelib/fs.stat": "^1.0.1",
+				"glob-parent": "^3.1.0",
+				"is-glob": "^4.0.0",
+				"merge2": "^1.2.1",
+				"micromatch": "^3.1.10"
 			},
 			"dependencies": {
 				"is-glob": {
@@ -3500,7 +3500,7 @@
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.1"
 					}
 				}
 			}
@@ -3522,13 +3522,13 @@
 			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
 			"integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
 			"requires": {
-				"core-js": "1.2.7",
-				"isomorphic-fetch": "2.2.1",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"promise": "7.3.1",
-				"setimmediate": "1.0.5",
-				"ua-parser-js": "0.7.17"
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.9"
 			},
 			"dependencies": {
 				"core-js": {
@@ -3544,8 +3544,8 @@
 			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "1.0.5",
-				"object-assign": "4.1.1"
+				"escape-string-regexp": "^1.0.5",
+				"object-assign": "^4.1.0"
 			}
 		},
 		"filename-regex": {
@@ -3560,10 +3560,10 @@
 			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "2.0.1",
-				"is-number": "3.0.0",
-				"repeat-string": "1.6.1",
-				"to-regex-range": "2.1.1"
+				"extend-shallow": "^2.0.1",
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1",
+				"to-regex-range": "^2.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -3572,7 +3572,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -3584,12 +3584,12 @@
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"on-finished": "2.3.0",
-				"parseurl": "1.3.2",
-				"statuses": "1.4.0",
-				"unpipe": "1.0.0"
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.2",
+				"statuses": "~1.4.0",
+				"unpipe": "~1.0.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -3609,9 +3609,9 @@
 			"integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
 			"dev": true,
 			"requires": {
-				"commondir": "1.0.1",
-				"make-dir": "1.3.0",
-				"pkg-dir": "2.0.0"
+				"commondir": "^1.0.1",
+				"make-dir": "^1.0.0",
+				"pkg-dir": "^2.0.0"
 			}
 		},
 		"find-up": {
@@ -3620,8 +3620,8 @@
 			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 			"dev": true,
 			"requires": {
-				"path-exists": "2.1.0",
-				"pinkie-promise": "2.0.1"
+				"path-exists": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			},
 			"dependencies": {
 				"path-exists": {
@@ -3630,7 +3630,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
@@ -3647,8 +3647,8 @@
 			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.4"
 			}
 		},
 		"for-in": {
@@ -3663,7 +3663,7 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "1.0.2"
+				"for-in": "^1.0.1"
 			}
 		},
 		"foreach": {
@@ -3684,7 +3684,7 @@
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
 			"requires": {
-				"map-cache": "0.2.2"
+				"map-cache": "^0.2.2"
 			}
 		},
 		"fresh": {
@@ -3699,8 +3699,8 @@
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0"
 			}
 		},
 		"front-matter": {
@@ -3709,7 +3709,7 @@
 			"integrity": "sha1-cgOviWzjV+4E4qpFFp6pHtf2dQQ=",
 			"dev": true,
 			"requires": {
-				"js-yaml": "3.10.0"
+				"js-yaml": "^3.10.0"
 			}
 		},
 		"fs-write-stream-atomic": {
@@ -3718,10 +3718,10 @@
 			"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"iferr": "0.1.5",
-				"imurmurhash": "0.1.4",
-				"readable-stream": "2.3.3"
+				"graceful-fs": "^4.1.2",
+				"iferr": "^0.1.5",
+				"imurmurhash": "^0.1.4",
+				"readable-stream": "1 || 2"
 			}
 		},
 		"fs.realpath": {
@@ -3737,8 +3737,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "2.10.0",
-				"node-pre-gyp": "0.10.0"
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -3771,12 +3771,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
@@ -3791,17 +3793,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -3918,7 +3923,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -3930,6 +3936,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "1.0.1"
 					}
@@ -3944,6 +3951,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "1.1.11"
 					}
@@ -3951,12 +3959,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "5.1.1",
 						"yallist": "3.0.2"
@@ -3975,6 +3985,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4055,7 +4066,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4067,6 +4079,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1.0.2"
 					}
@@ -4188,6 +4201,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -4289,12 +4303,12 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-base": {
@@ -4303,8 +4317,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
 			},
 			"dependencies": {
 				"glob-parent": {
@@ -4313,7 +4327,7 @@
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 					"dev": true,
 					"requires": {
-						"is-glob": "2.0.1"
+						"is-glob": "^2.0.0"
 					}
 				},
 				"is-extglob": {
@@ -4328,7 +4342,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				}
 			}
@@ -4339,8 +4353,8 @@
 			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 			"dev": true,
 			"requires": {
-				"is-glob": "3.1.0",
-				"path-dirname": "1.0.2"
+				"is-glob": "^3.1.0",
+				"path-dirname": "^1.0.0"
 			}
 		},
 		"glob-to-regexp": {
@@ -4355,7 +4369,7 @@
 			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
 			"dev": true,
 			"requires": {
-				"ini": "1.3.5"
+				"ini": "^1.3.4"
 			}
 		},
 		"globby": {
@@ -4364,13 +4378,13 @@
 			"integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
 			"dev": true,
 			"requires": {
-				"array-union": "1.0.2",
-				"dir-glob": "2.0.0",
-				"fast-glob": "2.2.2",
-				"glob": "7.1.2",
-				"ignore": "3.3.8",
-				"pify": "3.0.0",
-				"slash": "1.0.0"
+				"array-union": "^1.0.1",
+				"dir-glob": "^2.0.0",
+				"fast-glob": "^2.0.2",
+				"glob": "^7.1.2",
+				"ignore": "^3.3.5",
+				"pify": "^3.0.0",
+				"slash": "^1.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -4393,7 +4407,7 @@
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
 			"dev": true,
 			"requires": {
-				"function-bind": "1.1.1"
+				"function-bind": "^1.0.2"
 			}
 		},
 		"has-ansi": {
@@ -4402,7 +4416,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-flag": {
@@ -4422,9 +4436,9 @@
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"get-value": "2.0.6",
-				"has-values": "1.0.0",
-				"isobject": "3.0.1"
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
 			}
 		},
 		"has-values": {
@@ -4433,8 +4447,8 @@
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -4443,7 +4457,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -4454,8 +4468,8 @@
 			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"hash.js": {
@@ -4464,8 +4478,8 @@
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.1"
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"he": {
@@ -4480,9 +4494,9 @@
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"dev": true,
 			"requires": {
-				"hash.js": "1.1.3",
-				"minimalistic-assert": "1.0.1",
-				"minimalistic-crypto-utils": "1.0.1"
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"hoist-non-react-statics": {
@@ -4508,11 +4522,11 @@
 			"integrity": "sha512-7hIW7YinOYUpo//kSYcPB6dCKoceKLmOwjEMmhIobHuWGDVl0Nwe4l68mdG/Ru0wcUxQjVMEoZpkalZ/SE7zog==",
 			"dev": true,
 			"requires": {
-				"es6-templates": "0.2.3",
-				"fastparse": "1.1.1",
-				"html-minifier": "3.5.16",
-				"loader-utils": "1.1.0",
-				"object-assign": "4.1.1"
+				"es6-templates": "^0.2.3",
+				"fastparse": "^1.1.1",
+				"html-minifier": "^3.5.8",
+				"loader-utils": "^1.1.0",
+				"object-assign": "^4.1.1"
 			}
 		},
 		"html-minifier": {
@@ -4521,13 +4535,13 @@
 			"integrity": "sha512-zP5EfLSpiLRp0aAgud4CQXPQZm9kXwWjR/cF0PfdOj+jjWnOaCgeZcll4kYXSvIBPeUMmyaSc7mM4IDtA+kboA==",
 			"dev": true,
 			"requires": {
-				"camel-case": "3.0.0",
-				"clean-css": "4.1.11",
-				"commander": "2.15.1",
-				"he": "1.1.1",
-				"param-case": "2.1.1",
-				"relateurl": "0.2.7",
-				"uglify-js": "3.3.26"
+				"camel-case": "3.0.x",
+				"clean-css": "4.1.x",
+				"commander": "2.15.x",
+				"he": "1.1.x",
+				"param-case": "2.1.x",
+				"relateurl": "0.2.x",
+				"uglify-js": "3.3.x"
 			}
 		},
 		"http-errors": {
@@ -4536,10 +4550,10 @@
 			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
 			"dev": true,
 			"requires": {
-				"depd": "1.1.2",
+				"depd": "~1.1.2",
 				"inherits": "2.0.3",
 				"setprototypeof": "1.1.0",
-				"statuses": "1.4.0"
+				"statuses": ">= 1.4.0 < 2"
 			}
 		},
 		"https-browserify": {
@@ -4554,9 +4568,9 @@
 			"integrity": "sha1-xp7XTi0neXaaF7qDmbVM4LY8EsM=",
 			"dev": true,
 			"requires": {
-				"is-ci": "1.1.0",
-				"normalize-path": "1.0.0",
-				"strip-indent": "2.0.0"
+				"is-ci": "^1.0.10",
+				"normalize-path": "^1.0.0",
+				"strip-indent": "^2.0.0"
 			},
 			"dependencies": {
 				"normalize-path": {
@@ -4590,7 +4604,7 @@
 			"integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
 			"dev": true,
 			"requires": {
-				"postcss": "6.0.22"
+				"postcss": "^6.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -4599,7 +4613,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -4608,9 +4622,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -4625,9 +4639,9 @@
 					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.4.1",
-						"source-map": "0.6.1",
-						"supports-color": "5.4.0"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.4.0"
 					}
 				},
 				"source-map": {
@@ -4642,7 +4656,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -4676,8 +4690,8 @@
 			"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
 			"dev": true,
 			"requires": {
-				"caller-path": "2.0.0",
-				"resolve-from": "3.0.0"
+				"caller-path": "^2.0.0",
+				"resolve-from": "^3.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -4694,7 +4708,7 @@
 			"integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "3.0.0"
+				"resolve-from": "^3.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -4741,8 +4755,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -4763,18 +4777,18 @@
 			"integrity": "sha1-dEi/qSQJKvMR1HFzu6uZDK4rsCc=",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "1.4.0",
-				"ansi-regex": "2.1.1",
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"cli-width": "1.1.1",
-				"figures": "1.7.0",
-				"lodash": "3.10.1",
-				"readline2": "1.0.1",
-				"run-async": "0.1.0",
-				"rx-lite": "3.1.2",
-				"strip-ansi": "3.0.1",
-				"through": "2.3.8"
+				"ansi-escapes": "^1.1.0",
+				"ansi-regex": "^2.0.0",
+				"chalk": "^1.0.0",
+				"cli-cursor": "^1.0.1",
+				"cli-width": "^1.0.1",
+				"figures": "^1.3.5",
+				"lodash": "^3.3.1",
+				"readline2": "^1.0.1",
+				"run-async": "^0.1.0",
+				"rx-lite": "^3.1.2",
+				"strip-ansi": "^3.0.0",
+				"through": "^2.3.6"
 			},
 			"dependencies": {
 				"lodash": {
@@ -4803,7 +4817,7 @@
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -4812,7 +4826,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -4835,8 +4849,8 @@
 			"integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
 			"dev": true,
 			"requires": {
-				"is-alphabetical": "1.0.2",
-				"is-decimal": "1.0.2"
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0"
 			}
 		},
 		"is-arrayish": {
@@ -4851,7 +4865,7 @@
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"dev": true,
 			"requires": {
-				"binary-extensions": "1.11.0"
+				"binary-extensions": "^1.0.0"
 			}
 		},
 		"is-buffer": {
@@ -4866,7 +4880,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-ci": {
@@ -4875,7 +4889,7 @@
 			"integrity": "sha1-JH5BYueGDOu9rzC3dNawrH3P56U=",
 			"dev": true,
 			"requires": {
-				"ci-info": "1.1.2"
+				"ci-info": "^1.0.0"
 			}
 		},
 		"is-data-descriptor": {
@@ -4884,7 +4898,7 @@
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -4893,7 +4907,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -4910,9 +4924,9 @@
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "0.1.6",
-				"is-data-descriptor": "0.1.4",
-				"kind-of": "5.1.0"
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -4941,7 +4955,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "2.0.0"
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -4962,7 +4976,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -4971,13 +4985,8 @@
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
-		},
-		"is-function": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-			"integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
 		},
 		"is-glob": {
 			"version": "3.1.0",
@@ -4985,7 +4994,7 @@
 			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "2.1.1"
+				"is-extglob": "^2.1.0"
 			}
 		},
 		"is-hexadecimal": {
@@ -5000,7 +5009,7 @@
 			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -5009,7 +5018,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -5026,7 +5035,7 @@
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 			"dev": true,
 			"requires": {
-				"is-number": "4.0.0"
+				"is-number": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -5048,7 +5057,7 @@
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.1"
 			}
 		},
 		"is-posix-bracket": {
@@ -5074,7 +5083,7 @@
 			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
 			"dev": true,
 			"requires": {
-				"html-comment-regex": "1.1.1"
+				"html-comment-regex": "^1.1.0"
 			}
 		},
 		"is-text-path": {
@@ -5083,7 +5092,7 @@
 			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
 			"dev": true,
 			"requires": {
-				"text-extensions": "1.7.0"
+				"text-extensions": "^1.0.0"
 			}
 		},
 		"is-utf8": {
@@ -5132,8 +5141,8 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
-				"node-fetch": "1.7.3",
-				"whatwg-fetch": "2.0.3"
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
 			}
 		},
 		"js-base64": {
@@ -5153,8 +5162,8 @@
 			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.9",
-				"esprima": "4.0.0"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"jsesc": {
@@ -5205,10 +5214,10 @@
 			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "4.0.0",
-				"pify": "3.0.0",
-				"strip-bom": "3.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
 			},
 			"dependencies": {
 				"parse-json": {
@@ -5217,8 +5226,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "1.3.1",
-						"json-parse-better-errors": "1.0.2"
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
 					}
 				},
 				"pify": {
@@ -5235,9 +5244,9 @@
 			"integrity": "sha1-MY9JkFzopwnft8w/FvPv47zx3QU=",
 			"dev": true,
 			"requires": {
-				"in-publish": "2.0.0",
-				"semver": "5.4.1",
-				"source-map": "0.5.7"
+				"in-publish": "^2.0.0",
+				"semver": "^5.3.0",
+				"source-map": "^0.5.6"
 			}
 		},
 		"loader-runner": {
@@ -5252,9 +5261,9 @@
 			"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
 			"dev": true,
 			"requires": {
-				"big.js": "3.2.0",
-				"emojis-list": "2.1.0",
-				"json5": "0.5.1"
+				"big.js": "^3.1.3",
+				"emojis-list": "^2.0.0",
+				"json5": "^0.5.0"
 			}
 		},
 		"locate-path": {
@@ -5263,8 +5272,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
@@ -5363,7 +5372,7 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1"
+				"chalk": "^2.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -5372,7 +5381,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -5381,9 +5390,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -5398,7 +5407,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -5409,8 +5418,8 @@
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "1.4.0",
-				"cli-cursor": "1.0.2"
+				"ansi-escapes": "^1.0.0",
+				"cli-cursor": "^1.0.2"
 			}
 		},
 		"loglevelnext": {
@@ -5419,8 +5428,8 @@
 			"integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
 			"dev": true,
 			"requires": {
-				"es6-symbol": "3.1.1",
-				"object.assign": "4.1.0"
+				"es6-symbol": "^3.1.1",
+				"object.assign": "^4.1.0"
 			}
 		},
 		"long": {
@@ -5440,7 +5449,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"requires": {
-				"js-tokens": "3.0.2"
+				"js-tokens": "^3.0.0"
 			}
 		},
 		"loud-rejection": {
@@ -5449,8 +5458,8 @@
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"dev": true,
 			"requires": {
-				"currently-unhandled": "0.4.1",
-				"signal-exit": "3.0.2"
+				"currently-unhandled": "^0.4.1",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"lower-case": {
@@ -5465,8 +5474,8 @@
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"macaddress": {
@@ -5481,7 +5490,7 @@
 			"integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
 			"dev": true,
 			"requires": {
-				"vlq": "0.2.3"
+				"vlq": "^0.2.2"
 			},
 			"dependencies": {
 				"vlq": {
@@ -5498,7 +5507,7 @@
 			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"dev": true,
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -5527,7 +5536,7 @@
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"dev": true,
 			"requires": {
-				"object-visit": "1.0.1"
+				"object-visit": "^1.0.0"
 			}
 		},
 		"markdown-escapes": {
@@ -5560,8 +5569,8 @@
 			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
 			"dev": true,
 			"requires": {
-				"hash-base": "3.0.4",
-				"inherits": "2.0.3"
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"mdast-util-compact": {
@@ -5570,8 +5579,8 @@
 			"integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
 			"dev": true,
 			"requires": {
-				"unist-util-modify-children": "1.1.2",
-				"unist-util-visit": "1.3.1"
+				"unist-util-modify-children": "^1.0.0",
+				"unist-util-visit": "^1.1.0"
 			}
 		},
 		"media-typer": {
@@ -5586,8 +5595,8 @@
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"dev": true,
 			"requires": {
-				"errno": "0.1.7",
-				"readable-stream": "2.3.3"
+				"errno": "^0.1.3",
+				"readable-stream": "^2.0.1"
 			}
 		},
 		"meow": {
@@ -5596,16 +5605,16 @@
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "2.1.0",
-				"decamelize": "1.2.0",
-				"loud-rejection": "1.6.0",
-				"map-obj": "1.0.1",
-				"minimist": "1.2.0",
-				"normalize-package-data": "2.4.0",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"redent": "1.0.0",
-				"trim-newlines": "1.0.0"
+				"camelcase-keys": "^2.0.0",
+				"decamelize": "^1.1.2",
+				"loud-rejection": "^1.0.0",
+				"map-obj": "^1.0.1",
+				"minimist": "^1.1.3",
+				"normalize-package-data": "^2.3.4",
+				"object-assign": "^4.0.1",
+				"read-pkg-up": "^1.0.1",
+				"redent": "^1.0.0",
+				"trim-newlines": "^1.0.0"
 			}
 		},
 		"merge-descriptors": {
@@ -5632,19 +5641,19 @@
 			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "4.0.0",
-				"array-unique": "0.3.2",
-				"braces": "2.3.2",
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"extglob": "2.0.4",
-				"fragment-cache": "0.2.1",
-				"kind-of": "6.0.2",
-				"nanomatch": "1.2.9",
-				"object.pick": "1.3.0",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
 			}
 		},
 		"miller-rabin": {
@@ -5653,8 +5662,8 @@
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0"
+				"bn.js": "^4.0.0",
+				"brorand": "^1.0.1"
 			}
 		},
 		"mime": {
@@ -5675,7 +5684,7 @@
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.33.0"
+				"mime-db": "~1.33.0"
 			}
 		},
 		"mimic-fn": {
@@ -5702,7 +5711,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -5717,16 +5726,16 @@
 			"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
 			"dev": true,
 			"requires": {
-				"concat-stream": "1.6.2",
-				"duplexify": "3.6.0",
-				"end-of-stream": "1.4.1",
-				"flush-write-stream": "1.0.3",
-				"from2": "2.3.0",
-				"parallel-transform": "1.1.0",
-				"pump": "2.0.1",
-				"pumpify": "1.5.1",
-				"stream-each": "1.2.2",
-				"through2": "2.0.3"
+				"concat-stream": "^1.5.0",
+				"duplexify": "^3.4.2",
+				"end-of-stream": "^1.1.0",
+				"flush-write-stream": "^1.0.0",
+				"from2": "^2.1.0",
+				"parallel-transform": "^1.1.0",
+				"pump": "^2.0.1",
+				"pumpify": "^1.3.3",
+				"stream-each": "^1.1.0",
+				"through2": "^2.0.0"
 			}
 		},
 		"mixin-deep": {
@@ -5735,8 +5744,8 @@
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"dev": true,
 			"requires": {
-				"for-in": "1.0.2",
-				"is-extendable": "1.0.1"
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -5745,7 +5754,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "2.0.4"
+						"is-plain-object": "^2.0.4"
 					}
 				}
 			}
@@ -5773,12 +5782,12 @@
 			"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
 			"dev": true,
 			"requires": {
-				"aproba": "1.2.0",
-				"copy-concurrently": "1.0.5",
-				"fs-write-stream-atomic": "1.0.10",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2",
-				"run-queue": "1.0.3"
+				"aproba": "^1.1.1",
+				"copy-concurrently": "^1.0.0",
+				"fs-write-stream-atomic": "^1.0.8",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.5.4",
+				"run-queue": "^1.0.3"
 			}
 		},
 		"ms": {
@@ -5806,18 +5815,18 @@
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "4.0.0",
-				"array-unique": "0.3.2",
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"fragment-cache": "0.2.1",
-				"is-odd": "2.0.0",
-				"is-windows": "1.0.2",
-				"kind-of": "6.0.2",
-				"object.pick": "1.3.0",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-odd": "^2.0.0",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
 			}
 		},
 		"negotiator": {
@@ -5844,7 +5853,7 @@
 			"integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
 			"dev": true,
 			"requires": {
-				"lower-case": "1.1.4"
+				"lower-case": "^1.1.1"
 			}
 		},
 		"node-fetch": {
@@ -5852,8 +5861,8 @@
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
 			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
 			"requires": {
-				"encoding": "0.1.12",
-				"is-stream": "1.1.0"
+				"encoding": "^0.1.11",
+				"is-stream": "^1.0.1"
 			}
 		},
 		"node-libs-browser": {
@@ -5862,28 +5871,28 @@
 			"integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
 			"dev": true,
 			"requires": {
-				"assert": "1.4.1",
-				"browserify-zlib": "0.2.0",
-				"buffer": "4.9.1",
-				"console-browserify": "1.1.0",
-				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.12.0",
-				"domain-browser": "1.2.0",
-				"events": "1.1.1",
-				"https-browserify": "1.0.0",
-				"os-browserify": "0.3.0",
+				"assert": "^1.1.1",
+				"browserify-zlib": "^0.2.0",
+				"buffer": "^4.3.0",
+				"console-browserify": "^1.1.0",
+				"constants-browserify": "^1.0.0",
+				"crypto-browserify": "^3.11.0",
+				"domain-browser": "^1.1.1",
+				"events": "^1.0.0",
+				"https-browserify": "^1.0.0",
+				"os-browserify": "^0.3.0",
 				"path-browserify": "0.0.0",
-				"process": "0.11.10",
-				"punycode": "1.4.1",
-				"querystring-es3": "0.2.1",
-				"readable-stream": "2.3.3",
-				"stream-browserify": "2.0.1",
-				"stream-http": "2.8.2",
-				"string_decoder": "1.0.3",
-				"timers-browserify": "2.0.10",
+				"process": "^0.11.10",
+				"punycode": "^1.2.4",
+				"querystring-es3": "^0.2.0",
+				"readable-stream": "^2.3.3",
+				"stream-browserify": "^2.0.1",
+				"stream-http": "^2.7.2",
+				"string_decoder": "^1.0.0",
+				"timers-browserify": "^2.0.4",
 				"tty-browserify": "0.0.0",
-				"url": "0.11.0",
-				"util": "0.10.3",
+				"url": "^0.11.0",
+				"util": "^0.10.3",
 				"vm-browserify": "0.0.4"
 			},
 			"dependencies": {
@@ -5893,9 +5902,9 @@
 					"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 					"dev": true,
 					"requires": {
-						"base64-js": "1.2.1",
-						"ieee754": "1.1.8",
-						"isarray": "1.0.0"
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4",
+						"isarray": "^1.0.0"
 					}
 				},
 				"punycode": {
@@ -5918,10 +5927,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "2.5.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.4.1",
-				"validate-npm-package-license": "3.0.1"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
@@ -5930,7 +5939,7 @@
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "1.1.0"
+				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"normalize-range": {
@@ -5945,10 +5954,10 @@
 			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
 			"dev": true,
 			"requires": {
-				"object-assign": "4.1.1",
-				"prepend-http": "1.0.4",
-				"query-string": "4.3.4",
-				"sort-keys": "1.1.2"
+				"object-assign": "^4.0.1",
+				"prepend-http": "^1.0.0",
+				"query-string": "^4.1.0",
+				"sort-keys": "^1.0.0"
 			}
 		},
 		"npm-run-path": {
@@ -5957,7 +5966,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"num2fraction": {
@@ -5983,9 +5992,9 @@
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
 			"requires": {
-				"copy-descriptor": "0.1.1",
-				"define-property": "0.2.5",
-				"kind-of": "3.2.2"
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
 			},
 			"dependencies": {
 				"define-property": {
@@ -5994,7 +6003,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"kind-of": {
@@ -6003,7 +6012,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -6020,7 +6029,7 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.0"
 			}
 		},
 		"object.assign": {
@@ -6029,10 +6038,10 @@
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"function-bind": "1.1.1",
-				"has-symbols": "1.0.0",
-				"object-keys": "1.0.11"
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
 			}
 		},
 		"object.omit": {
@@ -6041,8 +6050,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
 			}
 		},
 		"object.pick": {
@@ -6051,7 +6060,7 @@
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
 			"requires": {
-				"isobject": "3.0.1"
+				"isobject": "^3.0.1"
 			}
 		},
 		"on-finished": {
@@ -6069,7 +6078,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"onetime": {
@@ -6084,12 +6093,12 @@
 			"integrity": "sha512-hNNlAd3gfv/iPmsNxYoAPLvxg7HuPozww7fFonMZvL84tP6Ox5igfk5j/+a9rtJJwqMgKK+JgWsAQik5o0HTLA==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"cli-cursor": "2.1.0",
-				"cli-spinners": "1.3.1",
-				"log-symbols": "2.2.0",
-				"strip-ansi": "4.0.0",
-				"wcwidth": "1.0.1"
+				"chalk": "^2.3.1",
+				"cli-cursor": "^2.1.0",
+				"cli-spinners": "^1.1.0",
+				"log-symbols": "^2.2.0",
+				"strip-ansi": "^4.0.0",
+				"wcwidth": "^1.0.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -6104,7 +6113,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -6113,9 +6122,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"cli-cursor": {
@@ -6124,7 +6133,7 @@
 					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 					"dev": true,
 					"requires": {
-						"restore-cursor": "2.0.0"
+						"restore-cursor": "^2.0.0"
 					}
 				},
 				"has-flag": {
@@ -6139,7 +6148,7 @@
 					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
 					"dev": true,
 					"requires": {
-						"mimic-fn": "1.2.0"
+						"mimic-fn": "^1.0.0"
 					}
 				},
 				"restore-cursor": {
@@ -6148,8 +6157,8 @@
 					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 					"dev": true,
 					"requires": {
-						"onetime": "2.0.1",
-						"signal-exit": "3.0.2"
+						"onetime": "^2.0.0",
+						"signal-exit": "^3.0.2"
 					}
 				},
 				"strip-ansi": {
@@ -6158,7 +6167,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"supports-color": {
@@ -6167,7 +6176,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -6190,7 +6199,7 @@
 			"integrity": "sha1-Yp0xcVAgnI/VCLoTdxPvS7kg6ds=",
 			"dev": true,
 			"requires": {
-				"p-map": "1.2.0"
+				"p-map": "^1.0.0"
 			}
 		},
 		"p-finally": {
@@ -6211,7 +6220,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "1.1.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-map": {
@@ -6232,9 +6241,9 @@
 			"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
 			"dev": true,
 			"requires": {
-				"cyclist": "0.2.2",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"cyclist": "~0.2.2",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.1.5"
 			}
 		},
 		"param-case": {
@@ -6243,7 +6252,7 @@
 			"integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
 			"dev": true,
 			"requires": {
-				"no-case": "2.3.2"
+				"no-case": "^2.2.0"
 			}
 		},
 		"parse-asn1": {
@@ -6252,11 +6261,11 @@
 			"integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
 			"dev": true,
 			"requires": {
-				"asn1.js": "4.10.1",
-				"browserify-aes": "1.2.0",
-				"create-hash": "1.2.0",
-				"evp_bytestokey": "1.0.3",
-				"pbkdf2": "3.0.16"
+				"asn1.js": "^4.0.0",
+				"browserify-aes": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.0",
+				"pbkdf2": "^3.0.3"
 			}
 		},
 		"parse-entities": {
@@ -6265,12 +6274,12 @@
 			"integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
 			"dev": true,
 			"requires": {
-				"character-entities": "1.2.2",
-				"character-entities-legacy": "1.1.2",
-				"character-reference-invalid": "1.1.2",
-				"is-alphanumerical": "1.0.2",
-				"is-decimal": "1.0.2",
-				"is-hexadecimal": "1.0.2"
+				"character-entities": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"character-reference-invalid": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
 			}
 		},
 		"parse-glob": {
@@ -6279,10 +6288,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
 			},
 			"dependencies": {
 				"is-extglob": {
@@ -6297,7 +6306,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "1.0.0"
+						"is-extglob": "^1.0.0"
 					}
 				}
 			}
@@ -6308,7 +6317,7 @@
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"dev": true,
 			"requires": {
-				"error-ex": "1.3.1"
+				"error-ex": "^1.2.0"
 			}
 		},
 		"parseurl": {
@@ -6365,9 +6374,9 @@
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"pbkdf2": {
@@ -6376,11 +6385,11 @@
 			"integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
 			"dev": true,
 			"requires": {
-				"create-hash": "1.2.0",
-				"create-hmac": "1.1.7",
-				"ripemd160": "2.0.2",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.11"
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"pify": {
@@ -6401,7 +6410,7 @@
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "2.0.4"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"pkg-dir": {
@@ -6410,7 +6419,7 @@
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0"
+				"find-up": "^2.1.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -6419,7 +6428,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				}
 			}
@@ -6436,10 +6445,10 @@
 			"integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"js-base64": "2.4.5",
-				"source-map": "0.5.7",
-				"supports-color": "3.2.3"
+				"chalk": "^1.1.3",
+				"js-base64": "^2.1.9",
+				"source-map": "^0.5.6",
+				"supports-color": "^3.2.3"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -6448,7 +6457,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -6459,9 +6468,9 @@
 			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-message-helpers": "2.0.0",
-				"reduce-css-calc": "1.3.0"
+				"postcss": "^5.0.2",
+				"postcss-message-helpers": "^2.0.0",
+				"reduce-css-calc": "^1.2.6"
 			}
 		},
 		"postcss-colormin": {
@@ -6470,9 +6479,9 @@
 			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
 			"dev": true,
 			"requires": {
-				"colormin": "1.1.2",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"colormin": "^1.0.5",
+				"postcss": "^5.0.13",
+				"postcss-value-parser": "^3.2.3"
 			}
 		},
 		"postcss-convert-values": {
@@ -6481,8 +6490,8 @@
 			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"postcss": "^5.0.11",
+				"postcss-value-parser": "^3.1.2"
 			}
 		},
 		"postcss-discard-comments": {
@@ -6491,7 +6500,7 @@
 			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.14"
 			}
 		},
 		"postcss-discard-duplicates": {
@@ -6500,7 +6509,7 @@
 			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.4"
 			}
 		},
 		"postcss-discard-empty": {
@@ -6509,7 +6518,7 @@
 			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.14"
 			}
 		},
 		"postcss-discard-overridden": {
@@ -6518,7 +6527,7 @@
 			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.16"
 			}
 		},
 		"postcss-discard-unused": {
@@ -6527,8 +6536,8 @@
 			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
+				"postcss": "^5.0.14",
+				"uniqs": "^2.0.0"
 			}
 		},
 		"postcss-filter-plugins": {
@@ -6537,8 +6546,8 @@
 			"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"uniqid": "4.1.1"
+				"postcss": "^5.0.4",
+				"uniqid": "^4.0.0"
 			}
 		},
 		"postcss-merge-idents": {
@@ -6547,9 +6556,9 @@
 			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
 			"dev": true,
 			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"has": "^1.0.1",
+				"postcss": "^5.0.10",
+				"postcss-value-parser": "^3.1.1"
 			}
 		},
 		"postcss-merge-longhand": {
@@ -6558,7 +6567,7 @@
 			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.4"
 			}
 		},
 		"postcss-merge-rules": {
@@ -6567,11 +6576,11 @@
 			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
 			"dev": true,
 			"requires": {
-				"browserslist": "1.7.7",
-				"caniuse-api": "1.6.1",
-				"postcss": "5.2.18",
-				"postcss-selector-parser": "2.2.3",
-				"vendors": "1.0.2"
+				"browserslist": "^1.5.2",
+				"caniuse-api": "^1.5.2",
+				"postcss": "^5.0.4",
+				"postcss-selector-parser": "^2.2.2",
+				"vendors": "^1.0.0"
 			}
 		},
 		"postcss-message-helpers": {
@@ -6586,9 +6595,9 @@
 			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
 			"dev": true,
 			"requires": {
-				"object-assign": "4.1.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"object-assign": "^4.0.1",
+				"postcss": "^5.0.4",
+				"postcss-value-parser": "^3.0.2"
 			}
 		},
 		"postcss-minify-gradients": {
@@ -6597,8 +6606,8 @@
 			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"postcss": "^5.0.12",
+				"postcss-value-parser": "^3.3.0"
 			}
 		},
 		"postcss-minify-params": {
@@ -6607,10 +6616,10 @@
 			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "1.0.2",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0",
-				"uniqs": "2.0.0"
+				"alphanum-sort": "^1.0.1",
+				"postcss": "^5.0.2",
+				"postcss-value-parser": "^3.0.2",
+				"uniqs": "^2.0.0"
 			}
 		},
 		"postcss-minify-selectors": {
@@ -6619,10 +6628,10 @@
 			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "1.0.2",
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-selector-parser": "2.2.3"
+				"alphanum-sort": "^1.0.2",
+				"has": "^1.0.1",
+				"postcss": "^5.0.14",
+				"postcss-selector-parser": "^2.0.0"
 			}
 		},
 		"postcss-modules-extract-imports": {
@@ -6631,7 +6640,7 @@
 			"integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
 			"dev": true,
 			"requires": {
-				"postcss": "6.0.22"
+				"postcss": "^6.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -6640,7 +6649,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -6649,9 +6658,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -6666,9 +6675,9 @@
 					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.4.1",
-						"source-map": "0.6.1",
-						"supports-color": "5.4.0"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.4.0"
 					}
 				},
 				"source-map": {
@@ -6683,7 +6692,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -6694,8 +6703,8 @@
 			"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
 			"dev": true,
 			"requires": {
-				"css-selector-tokenizer": "0.7.0",
-				"postcss": "6.0.22"
+				"css-selector-tokenizer": "^0.7.0",
+				"postcss": "^6.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -6704,7 +6713,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -6713,9 +6722,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -6730,9 +6739,9 @@
 					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.4.1",
-						"source-map": "0.6.1",
-						"supports-color": "5.4.0"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.4.0"
 					}
 				},
 				"source-map": {
@@ -6747,7 +6756,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -6758,8 +6767,8 @@
 			"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
 			"dev": true,
 			"requires": {
-				"css-selector-tokenizer": "0.7.0",
-				"postcss": "6.0.22"
+				"css-selector-tokenizer": "^0.7.0",
+				"postcss": "^6.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -6768,7 +6777,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -6777,9 +6786,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -6794,9 +6803,9 @@
 					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.4.1",
-						"source-map": "0.6.1",
-						"supports-color": "5.4.0"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.4.0"
 					}
 				},
 				"source-map": {
@@ -6811,7 +6820,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -6822,8 +6831,8 @@
 			"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
 			"dev": true,
 			"requires": {
-				"icss-replace-symbols": "1.1.0",
-				"postcss": "6.0.22"
+				"icss-replace-symbols": "^1.1.0",
+				"postcss": "^6.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -6832,7 +6841,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -6841,9 +6850,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -6858,9 +6867,9 @@
 					"integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.4.1",
-						"source-map": "0.6.1",
-						"supports-color": "5.4.0"
+						"chalk": "^2.4.1",
+						"source-map": "^0.6.1",
+						"supports-color": "^5.4.0"
 					}
 				},
 				"source-map": {
@@ -6875,7 +6884,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -6886,7 +6895,7 @@
 			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.5"
 			}
 		},
 		"postcss-normalize-url": {
@@ -6895,10 +6904,10 @@
 			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
 			"dev": true,
 			"requires": {
-				"is-absolute-url": "2.1.0",
-				"normalize-url": "1.9.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"is-absolute-url": "^2.0.0",
+				"normalize-url": "^1.4.0",
+				"postcss": "^5.0.14",
+				"postcss-value-parser": "^3.2.3"
 			}
 		},
 		"postcss-ordered-values": {
@@ -6907,8 +6916,8 @@
 			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"postcss": "^5.0.4",
+				"postcss-value-parser": "^3.0.1"
 			}
 		},
 		"postcss-reduce-idents": {
@@ -6917,8 +6926,8 @@
 			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"postcss": "^5.0.4",
+				"postcss-value-parser": "^3.0.2"
 			}
 		},
 		"postcss-reduce-initial": {
@@ -6927,7 +6936,7 @@
 			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
 			"dev": true,
 			"requires": {
-				"postcss": "5.2.18"
+				"postcss": "^5.0.4"
 			}
 		},
 		"postcss-reduce-transforms": {
@@ -6936,9 +6945,9 @@
 			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
 			"dev": true,
 			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0"
+				"has": "^1.0.1",
+				"postcss": "^5.0.8",
+				"postcss-value-parser": "^3.0.1"
 			}
 		},
 		"postcss-selector-parser": {
@@ -6947,9 +6956,9 @@
 			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
 			"dev": true,
 			"requires": {
-				"flatten": "1.0.2",
-				"indexes-of": "1.0.1",
-				"uniq": "1.0.1"
+				"flatten": "^1.0.2",
+				"indexes-of": "^1.0.1",
+				"uniq": "^1.0.1"
 			}
 		},
 		"postcss-svgo": {
@@ -6958,10 +6967,10 @@
 			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
 			"dev": true,
 			"requires": {
-				"is-svg": "2.1.0",
-				"postcss": "5.2.18",
-				"postcss-value-parser": "3.3.0",
-				"svgo": "0.7.2"
+				"is-svg": "^2.0.0",
+				"postcss": "^5.0.14",
+				"postcss-value-parser": "^3.2.3",
+				"svgo": "^0.7.0"
 			}
 		},
 		"postcss-unique-selectors": {
@@ -6970,9 +6979,9 @@
 			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
 			"dev": true,
 			"requires": {
-				"alphanum-sort": "1.0.2",
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
+				"alphanum-sort": "^1.0.1",
+				"postcss": "^5.0.4",
+				"uniqs": "^2.0.0"
 			}
 		},
 		"postcss-value-parser": {
@@ -6986,9 +6995,9 @@
 			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
 			"dev": true,
 			"requires": {
-				"has": "1.0.1",
-				"postcss": "5.2.18",
-				"uniqs": "2.0.0"
+				"has": "^1.0.1",
+				"postcss": "^5.0.4",
+				"uniqs": "^2.0.0"
 			}
 		},
 		"prepend-http": {
@@ -7026,7 +7035,7 @@
 			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
 			"requires": {
-				"asap": "2.0.6"
+				"asap": "~2.0.3"
 			}
 		},
 		"promise-inflight": {
@@ -7040,9 +7049,9 @@
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
 			"integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1"
+				"fbjs": "^0.8.16",
+				"loose-envify": "^1.3.1",
+				"object-assign": "^4.1.1"
 			}
 		},
 		"proxy-addr": {
@@ -7051,7 +7060,7 @@
 			"integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
 			"dev": true,
 			"requires": {
-				"forwarded": "0.1.2",
+				"forwarded": "~0.1.2",
 				"ipaddr.js": "1.6.0"
 			}
 		},
@@ -7073,11 +7082,11 @@
 			"integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.2.0",
-				"parse-asn1": "5.1.1",
-				"randombytes": "2.0.6"
+				"bn.js": "^4.1.0",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"parse-asn1": "^5.0.0",
+				"randombytes": "^2.0.1"
 			}
 		},
 		"pump": {
@@ -7086,8 +7095,8 @@
 			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "1.4.1",
-				"once": "1.4.0"
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
 			}
 		},
 		"pumpify": {
@@ -7096,9 +7105,9 @@
 			"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
 			"dev": true,
 			"requires": {
-				"duplexify": "3.6.0",
-				"inherits": "2.0.3",
-				"pump": "2.0.1"
+				"duplexify": "^3.6.0",
+				"inherits": "^2.0.3",
+				"pump": "^2.0.0"
 			}
 		},
 		"punycode": {
@@ -7125,8 +7134,8 @@
 			"integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
 			"dev": true,
 			"requires": {
-				"object-assign": "4.1.1",
-				"strict-uri-encode": "1.1.0"
+				"object-assign": "^4.1.0",
+				"strict-uri-encode": "^1.0.0"
 			}
 		},
 		"querystring": {
@@ -7147,9 +7156,9 @@
 			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
 			"dev": true,
 			"requires": {
-				"is-number": "4.0.0",
-				"kind-of": "6.0.2",
-				"math-random": "1.0.1"
+				"is-number": "^4.0.0",
+				"kind-of": "^6.0.0",
+				"math-random": "^1.0.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -7166,7 +7175,7 @@
 			"integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"randomfill": {
@@ -7175,8 +7184,8 @@
 			"integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
 			"dev": true,
 			"requires": {
-				"randombytes": "2.0.6",
-				"safe-buffer": "5.1.1"
+				"randombytes": "^2.0.5",
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"range-parser": {
@@ -7212,7 +7221,7 @@
 						"depd": "1.1.1",
 						"inherits": "2.0.3",
 						"setprototypeof": "1.0.3",
-						"statuses": "1.4.0"
+						"statuses": ">= 1.3.1 < 2"
 					}
 				},
 				"setprototypeof": {
@@ -7234,11 +7243,11 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
 			"integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
 			"requires": {
-				"create-react-class": "15.6.2",
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.0"
+				"create-react-class": "^15.6.0",
+				"fbjs": "^0.8.9",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.0",
+				"prop-types": "^15.5.10"
 			}
 		},
 		"react-dom": {
@@ -7246,10 +7255,10 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
 			"integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
 			"requires": {
-				"fbjs": "0.8.16",
-				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1",
-				"prop-types": "15.6.0"
+				"fbjs": "^0.8.9",
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.0",
+				"prop-types": "^15.5.10"
 			}
 		},
 		"react-feather": {
@@ -7269,9 +7278,9 @@
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "1.1.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "1.1.0"
+				"load-json-file": "^1.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^1.0.0"
 			},
 			"dependencies": {
 				"load-json-file": {
@@ -7280,11 +7289,11 @@
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"strip-bom": {
@@ -7293,7 +7302,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				}
 			}
@@ -7304,8 +7313,8 @@
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"dev": true,
 			"requires": {
-				"find-up": "1.1.2",
-				"read-pkg": "1.1.0"
+				"find-up": "^1.0.0",
+				"read-pkg": "^1.0.0"
 			}
 		},
 		"readable-stream": {
@@ -7314,13 +7323,13 @@
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
 			"dev": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~1.0.6",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.0.3",
+				"util-deprecate": "~1.0.1"
 			},
 			"dependencies": {
 				"isarray": {
@@ -7337,10 +7346,10 @@
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"readable-stream": "2.3.3",
-				"set-immediate-shim": "1.0.1"
+				"graceful-fs": "^4.1.2",
+				"minimatch": "^3.0.2",
+				"readable-stream": "^2.0.2",
+				"set-immediate-shim": "^1.0.1"
 			}
 		},
 		"readline2": {
@@ -7349,8 +7358,8 @@
 			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
 			"dev": true,
 			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
 				"mute-stream": "0.0.5"
 			}
 		},
@@ -7361,9 +7370,9 @@
 			"dev": true,
 			"requires": {
 				"ast-types": "0.9.6",
-				"esprima": "3.1.3",
-				"private": "0.1.8",
-				"source-map": "0.5.7"
+				"esprima": "~3.1.0",
+				"private": "~0.1.5",
+				"source-map": "~0.5.0"
 			},
 			"dependencies": {
 				"esprima": {
@@ -7380,8 +7389,8 @@
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 			"dev": true,
 			"requires": {
-				"indent-string": "2.1.0",
-				"strip-indent": "1.0.1"
+				"indent-string": "^2.1.0",
+				"strip-indent": "^1.0.1"
 			},
 			"dependencies": {
 				"indent-string": {
@@ -7390,7 +7399,7 @@
 					"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 					"dev": true,
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				}
 			}
@@ -7401,9 +7410,9 @@
 			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "0.4.2",
-				"math-expression-evaluator": "1.2.17",
-				"reduce-function-call": "1.0.2"
+				"balanced-match": "^0.4.2",
+				"math-expression-evaluator": "^1.2.14",
+				"reduce-function-call": "^1.0.1"
 			},
 			"dependencies": {
 				"balanced-match": {
@@ -7420,7 +7429,7 @@
 			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "0.4.2"
+				"balanced-match": "^0.4.2"
 			},
 			"dependencies": {
 				"balanced-match": {
@@ -7449,7 +7458,7 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "0.1.3"
+				"is-equal-shallow": "^0.1.3"
 			}
 		},
 		"regex-not": {
@@ -7458,8 +7467,8 @@
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "3.0.2",
-				"safe-regex": "1.1.0"
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"regexpu-core": {
@@ -7468,9 +7477,9 @@
 			"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
 			"dev": true,
 			"requires": {
-				"regenerate": "1.4.0",
-				"regjsgen": "0.2.0",
-				"regjsparser": "0.1.5"
+				"regenerate": "^1.2.1",
+				"regjsgen": "^0.2.0",
+				"regjsparser": "^0.1.4"
 			}
 		},
 		"regjsgen": {
@@ -7485,7 +7494,7 @@
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"dev": true,
 			"requires": {
-				"jsesc": "0.5.0"
+				"jsesc": "~0.5.0"
 			}
 		},
 		"relateurl": {
@@ -7500,9 +7509,9 @@
 			"integrity": "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==",
 			"dev": true,
 			"requires": {
-				"remark-parse": "4.0.0",
-				"remark-stringify": "4.0.0",
-				"unified": "6.2.0"
+				"remark-parse": "^4.0.0",
+				"remark-stringify": "^4.0.0",
+				"unified": "^6.0.0"
 			}
 		},
 		"remark-parse": {
@@ -7511,21 +7520,21 @@
 			"integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
 			"dev": true,
 			"requires": {
-				"collapse-white-space": "1.0.4",
-				"is-alphabetical": "1.0.2",
-				"is-decimal": "1.0.2",
-				"is-whitespace-character": "1.0.2",
-				"is-word-character": "1.0.2",
-				"markdown-escapes": "1.0.2",
-				"parse-entities": "1.1.2",
-				"repeat-string": "1.6.1",
-				"state-toggle": "1.0.1",
+				"collapse-white-space": "^1.0.2",
+				"is-alphabetical": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"is-word-character": "^1.0.0",
+				"markdown-escapes": "^1.0.0",
+				"parse-entities": "^1.0.2",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
 				"trim": "0.0.1",
-				"trim-trailing-lines": "1.1.1",
-				"unherit": "1.1.1",
-				"unist-util-remove-position": "1.1.2",
-				"vfile-location": "2.0.3",
-				"xtend": "4.0.1"
+				"trim-trailing-lines": "^1.0.0",
+				"unherit": "^1.0.4",
+				"unist-util-remove-position": "^1.0.0",
+				"vfile-location": "^2.0.0",
+				"xtend": "^4.0.1"
 			}
 		},
 		"remark-stringify": {
@@ -7534,20 +7543,20 @@
 			"integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
 			"dev": true,
 			"requires": {
-				"ccount": "1.0.3",
-				"is-alphanumeric": "1.0.0",
-				"is-decimal": "1.0.2",
-				"is-whitespace-character": "1.0.2",
-				"longest-streak": "2.0.2",
-				"markdown-escapes": "1.0.2",
-				"markdown-table": "1.1.2",
-				"mdast-util-compact": "1.0.1",
-				"parse-entities": "1.1.2",
-				"repeat-string": "1.6.1",
-				"state-toggle": "1.0.1",
-				"stringify-entities": "1.3.2",
-				"unherit": "1.1.1",
-				"xtend": "4.0.1"
+				"ccount": "^1.0.0",
+				"is-alphanumeric": "^1.0.0",
+				"is-decimal": "^1.0.0",
+				"is-whitespace-character": "^1.0.0",
+				"longest-streak": "^2.0.1",
+				"markdown-escapes": "^1.0.0",
+				"markdown-table": "^1.1.0",
+				"mdast-util-compact": "^1.0.0",
+				"parse-entities": "^1.0.2",
+				"repeat-string": "^1.5.4",
+				"state-toggle": "^1.0.0",
+				"stringify-entities": "^1.0.1",
+				"unherit": "^1.0.4",
+				"xtend": "^4.0.1"
 			}
 		},
 		"remove-trailing-separator": {
@@ -7574,7 +7583,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"replace-ext": {
@@ -7595,8 +7604,8 @@
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
-				"caller-path": "0.1.0",
-				"resolve-from": "1.0.1"
+				"caller-path": "^0.1.0",
+				"resolve-from": "^1.0.0"
 			},
 			"dependencies": {
 				"caller-path": {
@@ -7605,7 +7614,7 @@
 					"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 					"dev": true,
 					"requires": {
-						"callsites": "0.2.0"
+						"callsites": "^0.2.0"
 					}
 				},
 				"callsites": {
@@ -7634,7 +7643,7 @@
 			"integrity": "sha1-j7As/Vt9sgEY6IYxHxWvlb0V+9k=",
 			"dev": true,
 			"requires": {
-				"global-dirs": "0.1.1"
+				"global-dirs": "^0.1.0"
 			}
 		},
 		"resolve-pkg": {
@@ -7643,7 +7652,7 @@
 			"integrity": "sha1-4ZoV54rKLhJEYdySsuOUPvk0lNk=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "2.0.0"
+				"resolve-from": "^2.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -7666,8 +7675,8 @@
 			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 			"dev": true,
 			"requires": {
-				"exit-hook": "1.1.1",
-				"onetime": "1.1.0"
+				"exit-hook": "^1.0.0",
+				"onetime": "^1.0.0"
 			}
 		},
 		"ret": {
@@ -7682,7 +7691,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.0.5"
 			}
 		},
 		"ripemd160": {
@@ -7691,8 +7700,8 @@
 			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
 			"dev": true,
 			"requires": {
-				"hash-base": "3.0.4",
-				"inherits": "2.0.3"
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"run-async": {
@@ -7701,7 +7710,7 @@
 			"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0"
+				"once": "^1.3.0"
 			}
 		},
 		"run-queue": {
@@ -7710,7 +7719,7 @@
 			"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 			"dev": true,
 			"requires": {
-				"aproba": "1.2.0"
+				"aproba": "^1.1.1"
 			}
 		},
 		"rx": {
@@ -7737,7 +7746,7 @@
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
-				"ret": "0.1.15"
+				"ret": "~0.1.10"
 			}
 		},
 		"sax": {
@@ -7752,8 +7761,8 @@
 			"integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
 			"dev": true,
 			"requires": {
-				"ajv": "6.5.0",
-				"ajv-keywords": "3.2.0"
+				"ajv": "^6.1.0",
+				"ajv-keywords": "^3.1.0"
 			}
 		},
 		"semver": {
@@ -7769,18 +7778,18 @@
 			"dev": true,
 			"requires": {
 				"debug": "2.6.9",
-				"depd": "1.1.2",
-				"destroy": "1.0.4",
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"etag": "1.8.1",
+				"depd": "~1.1.2",
+				"destroy": "~1.0.4",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
 				"fresh": "0.5.2",
-				"http-errors": "1.6.3",
+				"http-errors": "~1.6.2",
 				"mime": "1.4.1",
 				"ms": "2.0.0",
-				"on-finished": "2.3.0",
-				"range-parser": "1.2.0",
-				"statuses": "1.4.0"
+				"on-finished": "~2.3.0",
+				"range-parser": "~1.2.0",
+				"statuses": "~1.4.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -7806,9 +7815,9 @@
 			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
 			"dev": true,
 			"requires": {
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"parseurl": "1.3.2",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.2",
 				"send": "0.16.2"
 			}
 		},
@@ -7824,10 +7833,10 @@
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "2.0.1",
-				"is-extendable": "0.1.1",
-				"is-plain-object": "2.0.4",
-				"split-string": "3.1.0"
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -7836,7 +7845,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -7858,8 +7867,8 @@
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"shebang-command": {
@@ -7868,7 +7877,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -7901,14 +7910,14 @@
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
-				"base": "0.11.2",
-				"debug": "2.6.9",
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"map-cache": "0.2.2",
-				"source-map": "0.5.7",
-				"source-map-resolve": "0.5.2",
-				"use": "3.1.0"
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -7926,7 +7935,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				},
 				"extend-shallow": {
@@ -7935,7 +7944,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				}
 			}
@@ -7946,9 +7955,9 @@
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"snapdragon-util": "3.0.1"
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -7957,7 +7966,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "1.0.2"
+						"is-descriptor": "^1.0.0"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -7966,7 +7975,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-data-descriptor": {
@@ -7975,7 +7984,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "6.0.2"
+						"kind-of": "^6.0.0"
 					}
 				},
 				"is-descriptor": {
@@ -7984,9 +7993,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
 					}
 				}
 			}
@@ -7997,7 +8006,7 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.2.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -8006,7 +8015,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -8017,7 +8026,7 @@
 			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
 			"dev": true,
 			"requires": {
-				"is-plain-obj": "1.1.0"
+				"is-plain-obj": "^1.0.0"
 			}
 		},
 		"source-list-map": {
@@ -8038,11 +8047,11 @@
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"dev": true,
 			"requires": {
-				"atob": "2.1.1",
-				"decode-uri-component": "0.2.0",
-				"resolve-url": "0.2.1",
-				"source-map-url": "0.4.0",
-				"urix": "0.1.0"
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
 			}
 		},
 		"source-map-url": {
@@ -8063,7 +8072,7 @@
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
 			"dev": true,
 			"requires": {
-				"spdx-license-ids": "1.2.2"
+				"spdx-license-ids": "^1.0.2"
 			}
 		},
 		"spdx-expression-parse": {
@@ -8084,7 +8093,7 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "3.0.2"
+				"extend-shallow": "^3.0.0"
 			}
 		},
 		"sprintf-js": {
@@ -8099,7 +8108,7 @@
 			"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"state-toggle": {
@@ -8114,8 +8123,8 @@
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
 			"requires": {
-				"define-property": "0.2.5",
-				"object-copy": "0.1.0"
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -8124,7 +8133,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "0.1.6"
+						"is-descriptor": "^0.1.0"
 					}
 				}
 			}
@@ -8141,8 +8150,8 @@
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"inherits": "~2.0.1",
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"stream-each": {
@@ -8151,8 +8160,8 @@
 			"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "1.4.1",
-				"stream-shift": "1.0.0"
+				"end-of-stream": "^1.1.0",
+				"stream-shift": "^1.0.0"
 			}
 		},
 		"stream-http": {
@@ -8161,11 +8170,11 @@
 			"integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
 			"dev": true,
 			"requires": {
-				"builtin-status-codes": "3.0.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.6",
-				"to-arraybuffer": "1.0.1",
-				"xtend": "4.0.1"
+				"builtin-status-codes": "^3.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.3.6",
+				"to-arraybuffer": "^1.0.0",
+				"xtend": "^4.0.0"
 			},
 			"dependencies": {
 				"process-nextick-args": {
@@ -8180,13 +8189,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"string_decoder": {
@@ -8195,7 +8204,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
-						"safe-buffer": "5.1.1"
+						"safe-buffer": "~5.1.0"
 					}
 				}
 			}
@@ -8224,9 +8233,9 @@
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"dev": true,
 			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
-				"strip-ansi": "3.0.1"
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
 			}
 		},
 		"string_decoder": {
@@ -8235,7 +8244,7 @@
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"stringify-entities": {
@@ -8244,10 +8253,10 @@
 			"integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
 			"dev": true,
 			"requires": {
-				"character-entities-html4": "1.1.2",
-				"character-entities-legacy": "1.1.2",
-				"is-alphanumerical": "1.0.2",
-				"is-hexadecimal": "1.0.2"
+				"character-entities-html4": "^1.0.0",
+				"character-entities-legacy": "^1.0.0",
+				"is-alphanumerical": "^1.0.0",
+				"is-hexadecimal": "^1.0.0"
 			}
 		},
 		"strip-ansi": {
@@ -8256,7 +8265,7 @@
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"strip-bom": {
@@ -8277,23 +8286,22 @@
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 			"dev": true,
 			"requires": {
-				"get-stdin": "4.0.1"
+				"get-stdin": "^4.0.1"
 			}
 		},
 		"styled-components": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-2.2.3.tgz",
-			"integrity": "sha512-KzdZv4zyZPLoM4V90Tu+3evqTBZt1quFC1DBt5SA7k4dY3ANWmK+LZiIk/Q99GzLisBiEjV+Fn9nyty9rrZ1jw==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/styled-components/-/styled-components-2.4.1.tgz",
+			"integrity": "sha1-ZjvQSF1LarRvlGIQ3APSOY0a3nQ=",
 			"requires": {
-				"buffer": "5.0.8",
-				"css-to-react-native": "2.0.4",
-				"fbjs": "0.8.16",
-				"hoist-non-react-statics": "1.2.0",
-				"is-function": "1.0.1",
-				"is-plain-object": "2.0.4",
-				"prop-types": "15.6.0",
-				"stylis": "3.4.3",
-				"supports-color": "3.2.3"
+				"buffer": "^5.0.3",
+				"css-to-react-native": "^2.0.3",
+				"fbjs": "^0.8.9",
+				"hoist-non-react-statics": "^1.2.0",
+				"is-plain-object": "^2.0.1",
+				"prop-types": "^15.5.4",
+				"stylis": "^3.4.0",
+				"supports-color": "^3.2.3"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -8301,15 +8309,15 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
 		},
 		"stylis": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/stylis/-/stylis-3.4.3.tgz",
-			"integrity": "sha512-ScmjgdIRsLVh6haWj5mmmKXW1vjWBdXUDOqDfcEBn5Pfm/TqW9rfVUk2kJUKGL43+7Opot5vWAJxV6oXLbU3yA=="
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.1.tgz",
+			"integrity": "sha512-yM4PyeHuwhIOUHNJxi1/Mbq8kVLv4AkyE7IYLP/LK0lIFcr3tRa2H1iZlBYKIxOlf+/jruBTe8DdKSyQX9w4OA=="
 		},
 		"stylis-rule-sheet": {
 			"version": "0.0.10",
@@ -8329,13 +8337,13 @@
 			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
 			"dev": true,
 			"requires": {
-				"coa": "1.0.4",
-				"colors": "1.1.2",
-				"csso": "2.3.2",
-				"js-yaml": "3.7.0",
-				"mkdirp": "0.5.1",
-				"sax": "1.2.4",
-				"whet.extend": "0.9.9"
+				"coa": "~1.0.1",
+				"colors": "~1.1.2",
+				"csso": "~2.3.1",
+				"js-yaml": "~3.7.0",
+				"mkdirp": "~0.5.1",
+				"sax": "~1.2.1",
+				"whet.extend": "~0.9.9"
 			},
 			"dependencies": {
 				"esprima": {
@@ -8350,8 +8358,8 @@
 					"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
 					"dev": true,
 					"requires": {
-						"argparse": "1.0.9",
-						"esprima": "2.7.3"
+						"argparse": "^1.0.7",
+						"esprima": "^2.6.0"
 					}
 				}
 			}
@@ -8392,8 +8400,8 @@
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.3",
-				"xtend": "4.0.1"
+				"readable-stream": "^2.1.5",
+				"xtend": "~4.0.1"
 			}
 		},
 		"timers-browserify": {
@@ -8402,7 +8410,7 @@
 			"integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
 			"dev": true,
 			"requires": {
-				"setimmediate": "1.0.5"
+				"setimmediate": "^1.0.4"
 			}
 		},
 		"to-arraybuffer": {
@@ -8417,7 +8425,7 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -8426,7 +8434,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -8437,10 +8445,10 @@
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"regex-not": "1.0.2",
-				"safe-regex": "1.1.0"
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -8449,8 +8457,8 @@
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dev": true,
 			"requires": {
-				"is-number": "3.0.0",
-				"repeat-string": "1.6.1"
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
 			}
 		},
 		"to-string-loader": {
@@ -8459,7 +8467,7 @@
 			"integrity": "sha1-e3qheJG3u0lHp6Eb+wO1/enG5pU=",
 			"dev": true,
 			"requires": {
-				"loader-utils": "0.2.17"
+				"loader-utils": "^0.2.16"
 			},
 			"dependencies": {
 				"loader-utils": {
@@ -8468,10 +8476,10 @@
 					"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
 					"dev": true,
 					"requires": {
-						"big.js": "3.2.0",
-						"emojis-list": "2.1.0",
-						"json5": "0.5.1",
-						"object-assign": "4.1.1"
+						"big.js": "^3.1.3",
+						"emojis-list": "^2.0.0",
+						"json5": "^0.5.0",
+						"object-assign": "^4.0.1"
 					}
 				}
 			}
@@ -8530,7 +8538,7 @@
 			"dev": true,
 			"requires": {
 				"media-typer": "0.3.0",
-				"mime-types": "2.1.18"
+				"mime-types": "~2.1.18"
 			}
 		},
 		"typedarray": {
@@ -8556,8 +8564,8 @@
 			"integrity": "sha512-XHxutZNxbx0UnqNUrjL/wvABLxirEYpbAnjCWGakPfQRJbbAGF2dI+YYw300F5mYKm7zBtgYiw3kOiQFobzglQ==",
 			"dev": true,
 			"requires": {
-				"commander": "2.15.1",
-				"source-map": "0.6.1"
+				"commander": "~2.15.0",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -8574,14 +8582,14 @@
 			"integrity": "sha512-hIQJ1yxAPhEA2yW/i7Fr+SXZVMp+VEI3d42RTHBgQd2yhp/1UdBcR3QEWPV5ahBxlqQDMEMTuTEvDHSFINfwSw==",
 			"dev": true,
 			"requires": {
-				"cacache": "10.0.4",
-				"find-cache-dir": "1.0.0",
-				"schema-utils": "0.4.5",
-				"serialize-javascript": "1.5.0",
-				"source-map": "0.6.1",
-				"uglify-es": "3.3.9",
-				"webpack-sources": "1.1.0",
-				"worker-farm": "1.6.0"
+				"cacache": "^10.0.4",
+				"find-cache-dir": "^1.0.0",
+				"schema-utils": "^0.4.5",
+				"serialize-javascript": "^1.4.0",
+				"source-map": "^0.6.1",
+				"uglify-es": "^3.3.4",
+				"webpack-sources": "^1.1.0",
+				"worker-farm": "^1.5.2"
 			},
 			"dependencies": {
 				"commander": {
@@ -8602,8 +8610,8 @@
 					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
 					"dev": true,
 					"requires": {
-						"commander": "2.13.0",
-						"source-map": "0.6.1"
+						"commander": "~2.13.0",
+						"source-map": "~0.6.1"
 					}
 				}
 			}
@@ -8614,8 +8622,8 @@
 			"integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"xtend": "4.0.1"
+				"inherits": "^2.0.1",
+				"xtend": "^4.0.1"
 			}
 		},
 		"unified": {
@@ -8624,12 +8632,12 @@
 			"integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
 			"dev": true,
 			"requires": {
-				"bail": "1.0.3",
-				"extend": "3.0.1",
-				"is-plain-obj": "1.1.0",
-				"trough": "1.0.2",
-				"vfile": "2.3.0",
-				"x-is-string": "0.1.0"
+				"bail": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"trough": "^1.0.0",
+				"vfile": "^2.0.0",
+				"x-is-string": "^0.1.0"
 			}
 		},
 		"unindent": {
@@ -8644,10 +8652,10 @@
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"dev": true,
 			"requires": {
-				"arr-union": "3.1.0",
-				"get-value": "2.0.6",
-				"is-extendable": "0.1.1",
-				"set-value": "0.4.3"
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -8656,7 +8664,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "0.1.1"
+						"is-extendable": "^0.1.0"
 					}
 				},
 				"set-value": {
@@ -8665,10 +8673,10 @@
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"to-object-path": "0.3.0"
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
 					}
 				}
 			}
@@ -8685,7 +8693,7 @@
 			"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
 			"dev": true,
 			"requires": {
-				"macaddress": "0.2.8"
+				"macaddress": "^0.2.8"
 			}
 		},
 		"uniqs": {
@@ -8700,7 +8708,7 @@
 			"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
 			"dev": true,
 			"requires": {
-				"unique-slug": "2.0.0"
+				"unique-slug": "^2.0.0"
 			}
 		},
 		"unique-slug": {
@@ -8709,7 +8717,7 @@
 			"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
 			"dev": true,
 			"requires": {
-				"imurmurhash": "0.1.4"
+				"imurmurhash": "^0.1.4"
 			}
 		},
 		"unist-util-find": {
@@ -8718,9 +8726,9 @@
 			"integrity": "sha1-EGK7tpKMepfGrcibU3RdTEbCIqI=",
 			"dev": true,
 			"requires": {
-				"lodash.iteratee": "4.7.0",
-				"remark": "5.1.0",
-				"unist-util-visit": "1.3.1"
+				"lodash.iteratee": "^4.5.0",
+				"remark": "^5.0.1",
+				"unist-util-visit": "^1.1.0"
 			},
 			"dependencies": {
 				"longest-streak": {
@@ -8741,9 +8749,9 @@
 					"integrity": "sha1-y0Y709vLS5l5STXu4c9x16jjBow=",
 					"dev": true,
 					"requires": {
-						"remark-parse": "1.1.0",
-						"remark-stringify": "1.1.0",
-						"unified": "4.2.1"
+						"remark-parse": "^1.1.0",
+						"remark-stringify": "^1.1.0",
+						"unified": "^4.1.1"
 					}
 				},
 				"remark-parse": {
@@ -8752,15 +8760,15 @@
 					"integrity": "sha1-w8oQ+ajaBGFcKPCapOMEUQUm7CE=",
 					"dev": true,
 					"requires": {
-						"collapse-white-space": "1.0.4",
-						"extend": "3.0.1",
-						"parse-entities": "1.1.2",
-						"repeat-string": "1.6.1",
+						"collapse-white-space": "^1.0.0",
+						"extend": "^3.0.0",
+						"parse-entities": "^1.0.2",
+						"repeat-string": "^1.5.4",
 						"trim": "0.0.1",
-						"trim-trailing-lines": "1.1.1",
-						"unherit": "1.1.1",
-						"unist-util-remove-position": "1.1.2",
-						"vfile-location": "2.0.3"
+						"trim-trailing-lines": "^1.0.0",
+						"unherit": "^1.0.4",
+						"unist-util-remove-position": "^1.0.0",
+						"vfile-location": "^2.0.0"
 					}
 				},
 				"remark-stringify": {
@@ -8769,14 +8777,14 @@
 					"integrity": "sha1-pxBeJbnuK/mkm3XSxCPxGwauIJI=",
 					"dev": true,
 					"requires": {
-						"ccount": "1.0.3",
-						"extend": "3.0.1",
-						"longest-streak": "1.0.0",
-						"markdown-table": "0.4.0",
-						"parse-entities": "1.1.2",
-						"repeat-string": "1.6.1",
-						"stringify-entities": "1.3.2",
-						"unherit": "1.1.1"
+						"ccount": "^1.0.0",
+						"extend": "^3.0.0",
+						"longest-streak": "^1.0.0",
+						"markdown-table": "^0.4.0",
+						"parse-entities": "^1.0.2",
+						"repeat-string": "^1.5.4",
+						"stringify-entities": "^1.0.1",
+						"unherit": "^1.0.4"
 					}
 				},
 				"unified": {
@@ -8785,12 +8793,12 @@
 					"integrity": "sha1-dv9Dqo2kMPbn5KVchOusKtLPzS4=",
 					"dev": true,
 					"requires": {
-						"bail": "1.0.3",
-						"extend": "3.0.1",
-						"has": "1.0.1",
-						"once": "1.4.0",
-						"trough": "1.0.2",
-						"vfile": "1.4.0"
+						"bail": "^1.0.0",
+						"extend": "^3.0.0",
+						"has": "^1.0.1",
+						"once": "^1.3.3",
+						"trough": "^1.0.0",
+						"vfile": "^1.0.0"
 					}
 				},
 				"vfile": {
@@ -8813,7 +8821,7 @@
 			"integrity": "sha512-GRi04yhng1WqBf5RBzPkOtWAadcZS2gvuOgNn/cyJBYNxtTuyYqTKN0eg4rC1YJwGnzrqfRB3dSKm8cNCjNirg==",
 			"dev": true,
 			"requires": {
-				"array-iterate": "1.1.2"
+				"array-iterate": "^1.0.0"
 			}
 		},
 		"unist-util-remove-position": {
@@ -8822,7 +8830,7 @@
 			"integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
 			"dev": true,
 			"requires": {
-				"unist-util-visit": "1.3.1"
+				"unist-util-visit": "^1.1.0"
 			}
 		},
 		"unist-util-stringify-position": {
@@ -8837,7 +8845,7 @@
 			"integrity": "sha512-0fdB9EQJU0tho5tK0VzOJzAQpPv2LyLZ030b10GxuzAWEfvd54mpY7BMjQ1L69k2YNvL+SvxRzH0yUIehOO8aA==",
 			"dev": true,
 			"requires": {
-				"unist-util-is": "2.1.2"
+				"unist-util-is": "^2.1.1"
 			}
 		},
 		"unpipe": {
@@ -8852,8 +8860,8 @@
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
 			"requires": {
-				"has-value": "0.3.1",
-				"isobject": "3.0.1"
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
 			},
 			"dependencies": {
 				"has-value": {
@@ -8862,9 +8870,9 @@
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
 					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "0.1.4",
-						"isobject": "2.1.0"
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -8904,7 +8912,7 @@
 			"integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
 			"dev": true,
 			"requires": {
-				"punycode": "2.1.1"
+				"punycode": "^2.1.0"
 			}
 		},
 		"urix": {
@@ -8937,7 +8945,7 @@
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 			"dev": true,
 			"requires": {
-				"kind-of": "6.0.2"
+				"kind-of": "^6.0.2"
 			}
 		},
 		"util": {
@@ -8981,8 +8989,8 @@
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "1.0.2",
-				"spdx-expression-parse": "1.0.4"
+				"spdx-correct": "~1.0.0",
+				"spdx-expression-parse": "~1.0.0"
 			}
 		},
 		"vary": {
@@ -9003,10 +9011,10 @@
 			"integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
 			"dev": true,
 			"requires": {
-				"is-buffer": "1.1.6",
+				"is-buffer": "^1.1.4",
 				"replace-ext": "1.0.0",
-				"unist-util-stringify-position": "1.1.2",
-				"vfile-message": "1.0.1"
+				"unist-util-stringify-position": "^1.0.0",
+				"vfile-message": "^1.0.0"
 			}
 		},
 		"vfile-location": {
@@ -9021,7 +9029,7 @@
 			"integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
 			"dev": true,
 			"requires": {
-				"unist-util-stringify-position": "1.1.2"
+				"unist-util-stringify-position": "^1.1.1"
 			}
 		},
 		"vlq": {
@@ -9045,16 +9053,16 @@
 			"integrity": "sha1-S+eypOSPj8/JzzZIxBnTEcUiFZ0=",
 			"dev": true,
 			"requires": {
-				"babel-polyfill": "6.26.0",
-				"chalk": "1.1.3",
-				"in-publish": "2.0.0",
+				"babel-polyfill": "^6.3.14",
+				"chalk": "^1.1.0",
+				"in-publish": "^2.0.0",
 				"inquirer": "0.11.0",
-				"lodash": "4.17.4",
-				"log-update": "1.0.2",
-				"minimist": "1.2.0",
-				"node-localstorage": "0.6.0",
-				"strip-ansi": "3.0.1",
-				"wrap-ansi": "2.1.0"
+				"lodash": "^4.5.1",
+				"log-update": "^1.0.2",
+				"minimist": "^1.2.0",
+				"node-localstorage": "^0.6.0",
+				"strip-ansi": "^3.0.0",
+				"wrap-ansi": "^2.0.0"
 			}
 		},
 		"watchpack": {
@@ -9063,9 +9071,9 @@
 			"integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
 			"dev": true,
 			"requires": {
-				"chokidar": "2.0.3",
-				"graceful-fs": "4.1.11",
-				"neo-async": "2.5.1"
+				"chokidar": "^2.0.2",
+				"graceful-fs": "^4.1.2",
+				"neo-async": "^2.5.0"
 			},
 			"dependencies": {
 				"chokidar": {
@@ -9074,18 +9082,18 @@
 					"integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
 					"dev": true,
 					"requires": {
-						"anymatch": "2.0.0",
-						"async-each": "1.0.1",
-						"braces": "2.3.2",
-						"fsevents": "1.2.4",
-						"glob-parent": "3.1.0",
-						"inherits": "2.0.3",
-						"is-binary-path": "1.0.1",
-						"is-glob": "4.0.0",
-						"normalize-path": "2.1.1",
-						"path-is-absolute": "1.0.1",
-						"readdirp": "2.1.0",
-						"upath": "1.1.0"
+						"anymatch": "^2.0.0",
+						"async-each": "^1.0.0",
+						"braces": "^2.3.0",
+						"fsevents": "^1.1.2",
+						"glob-parent": "^3.1.0",
+						"inherits": "^2.0.1",
+						"is-binary-path": "^1.0.0",
+						"is-glob": "^4.0.0",
+						"normalize-path": "^2.1.1",
+						"path-is-absolute": "^1.0.0",
+						"readdirp": "^2.0.0",
+						"upath": "^1.0.0"
 					}
 				},
 				"is-glob": {
@@ -9094,7 +9102,7 @@
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "2.1.1"
+						"is-extglob": "^2.1.1"
 					}
 				}
 			}
@@ -9105,7 +9113,7 @@
 			"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 			"dev": true,
 			"requires": {
-				"defaults": "1.0.3"
+				"defaults": "^1.0.3"
 			}
 		},
 		"webassemblyjs": {
@@ -9118,7 +9126,7 @@
 				"@webassemblyjs/validation": "1.4.3",
 				"@webassemblyjs/wasm-parser": "1.4.3",
 				"@webassemblyjs/wast-parser": "1.4.3",
-				"long": "3.2.0"
+				"long": "^3.2.0"
 			}
 		},
 		"webpack": {
@@ -9130,25 +9138,25 @@
 				"@webassemblyjs/ast": "1.4.3",
 				"@webassemblyjs/wasm-edit": "1.4.3",
 				"@webassemblyjs/wasm-parser": "1.4.3",
-				"acorn": "5.5.3",
-				"acorn-dynamic-import": "3.0.0",
-				"ajv": "6.5.0",
-				"ajv-keywords": "3.2.0",
-				"chrome-trace-event": "0.1.3",
-				"enhanced-resolve": "4.0.0",
-				"eslint-scope": "3.7.1",
-				"loader-runner": "2.3.0",
-				"loader-utils": "1.1.0",
-				"memory-fs": "0.4.1",
-				"micromatch": "3.1.10",
-				"mkdirp": "0.5.1",
-				"neo-async": "2.5.1",
-				"node-libs-browser": "2.1.0",
-				"schema-utils": "0.4.5",
-				"tapable": "1.0.0",
-				"uglifyjs-webpack-plugin": "1.2.5",
-				"watchpack": "1.6.0",
-				"webpack-sources": "1.1.0"
+				"acorn": "^5.0.0",
+				"acorn-dynamic-import": "^3.0.0",
+				"ajv": "^6.1.0",
+				"ajv-keywords": "^3.1.0",
+				"chrome-trace-event": "^0.1.1",
+				"enhanced-resolve": "^4.0.0",
+				"eslint-scope": "^3.7.1",
+				"loader-runner": "^2.3.0",
+				"loader-utils": "^1.1.0",
+				"memory-fs": "~0.4.1",
+				"micromatch": "^3.1.8",
+				"mkdirp": "~0.5.0",
+				"neo-async": "^2.5.0",
+				"node-libs-browser": "^2.0.0",
+				"schema-utils": "^0.4.4",
+				"tapable": "^1.0.0",
+				"uglifyjs-webpack-plugin": "^1.2.4",
+				"watchpack": "^1.5.0",
+				"webpack-sources": "^1.0.1"
 			}
 		},
 		"webpack-log": {
@@ -9157,10 +9165,10 @@
 			"integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.4.1",
-				"log-symbols": "2.2.0",
-				"loglevelnext": "1.0.5",
-				"uuid": "3.2.1"
+				"chalk": "^2.1.0",
+				"log-symbols": "^2.1.0",
+				"loglevelnext": "^1.0.1",
+				"uuid": "^3.1.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -9169,7 +9177,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -9178,9 +9186,9 @@
 					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.1",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "5.4.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
@@ -9195,7 +9203,7 @@
 					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "3.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -9212,8 +9220,8 @@
 			"integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
 			"dev": true,
 			"requires": {
-				"source-list-map": "2.0.0",
-				"source-map": "0.6.1"
+				"source-list-map": "^2.0.0",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -9241,7 +9249,7 @@
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"worker-farm": {
@@ -9250,7 +9258,7 @@
 			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
 			"dev": true,
 			"requires": {
-				"errno": "0.1.7"
+				"errno": "~0.1.7"
 			}
 		},
 		"wrap-ansi": {
@@ -9259,8 +9267,8 @@
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			}
 		},
 		"wrappy": {
@@ -9275,8 +9283,8 @@
 			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
 			"dev": true,
 			"requires": {
-				"async-limiter": "1.0.0",
-				"safe-buffer": "5.1.1"
+				"async-limiter": "~1.0.0",
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"x-is-string": {
@@ -9309,7 +9317,7 @@
 			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "4.1.0"
+				"camelcase": "^4.1.0"
 			}
 		},
 		"zen-observable": {


### PR DESCRIPTION
In order to incorporate this PR https://github.com/styled-components/styled-components/pull/1773

Which is required for designkit `npm run build` to work with typescript 2.9.1.

When I used alva to create a designkit for me to use, then went to install, I ended up on 2.9.2. So this was required.

This diff is gnarly. All I did was run `npm update styled-components`, and this is what happened.