### PR TITLE
fix: link breaking list bullets

### DIFF
--- a/src/link/index.tsx
+++ b/src/link/index.tsx
@@ -12,6 +12,7 @@ export interface LinkProps {
 }
 
 const StyledLink = styled.div`
+	display: inline-block;
 	color: ${(props: LinkProps) => props.color || 'inherit'};
 	font-family: ${fonts().NORMAL_FONT};
 `;


### PR DESCRIPTION
One of the developers at Peakfijn (Johannes) noticed the list bullets breaking on next line in the (start) guides overview. I recon it's related to divs being full blown blocks, and put into list items.

This is happening on MacOS Mojave, Chrome Version 70.0.3538.45 (Official Build) beta (64-bit).

## Before change

![screenshot 2018-10-05 at 14 25 40](https://user-images.githubusercontent.com/1203991/46535189-e6625680-c8aa-11e8-8cf0-b3ca621b2bae.png)

## After change

![screenshot 2018-10-05 at 14 27 10](https://user-images.githubusercontent.com/1203991/46535194-eb270a80-c8aa-11e8-95ca-1fe9165aa860.png)
