### PR TITLE
chore: remove explicit children props

### DIFF
--- a/src/01-page/index.tsx
+++ b/src/01-page/index.tsx
@@ -9,7 +9,7 @@ export interface SectionProps {
 	/** @name Text Color */
 	textColor?: Color;
 
-	children?: React.ReactNode;
+	
 }
 
 

--- a/src/app-frame/index.tsx
+++ b/src/app-frame/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import styled from "styled-components";
 
 export interface AppFrameProps {
-	children?: React.ReactNode;
+	
 }
 
 const StyledFrame = styled.div`

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -14,7 +14,7 @@ export interface ButtonProps {
 	color?: Color;
 
 	onClick?: React.MouseEventHandler<HTMLDivElement>;
-	children?: React.ReactNode;
+
 }
 
 export enum ButtonOrder {

--- a/src/copy/index.tsx
+++ b/src/copy/index.tsx
@@ -11,7 +11,7 @@ export interface CopyProps {
 	/** @name Color @default #000000 */ color?: string;
 	/** @name Uppercase @default false */ uppercase?: boolean;
 
-	children?: React.ReactNode;
+	
 }
 
 interface CopyProxyProps {

--- a/src/dropdown/index.tsx
+++ b/src/dropdown/index.tsx
@@ -9,7 +9,6 @@ export interface DropdownProps {
 	/** @name Text */ text: string;
 
 	/** @ignore */ onToggle(event: React.MouseEvent<HTMLElement>): void;
-	children: React.ReactNode;
 }
 
 interface StyledIconProps {

--- a/src/feature/index.tsx
+++ b/src/feature/index.tsx
@@ -28,7 +28,7 @@ export interface FeatureProps {
 	/** @name NegativeTop */
 	negativeTop?: boolean;
 
-	children?: React.ReactNode;
+	
 }
 
 export enum FeatureLevel {

--- a/src/footer/index.tsx
+++ b/src/footer/index.tsx
@@ -7,8 +7,6 @@ import Layout from '../layout';
 export interface FooterProps {
 	/** @copy @name Copyright */
 	copyright: string;
-
-	children: React.ReactNode;
 }
 
 const StyledFooter = styled.div`

--- a/src/headline/index.tsx
+++ b/src/headline/index.tsx
@@ -11,7 +11,7 @@ export interface HeadlineProps {
 	/** @name Color @default #000000 */ color?: string;
 	/** @name Uppercase @default false */ uppercase?: boolean;
 	/** @name Weight @default bold */ fontWeight?: Types.FontWeight;
-	children?: React.ReactNode;
+	
 }
 
 export enum HeadlineLevel {

--- a/src/icons/index.tsx
+++ b/src/icons/index.tsx
@@ -30,7 +30,6 @@ interface StyledIconProps {
 }
 
 interface IconRegistrySymbolProps {
-	children: React.ReactNode;
 	id: string;
 	size: "small" | "large";
 }

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -7,7 +7,7 @@ export interface LayoutProps {
 	/** @name Maximum width*/ maxWidth?: string;
 	/** @name Background color @default transparent */ backgroundColor?: string;
 	center?: boolean;
-	children?: React.ReactNode;
+	
 }
 
 export enum Direction {

--- a/src/link/index.tsx
+++ b/src/link/index.tsx
@@ -8,7 +8,7 @@ export interface LinkProps {
 	color?: Color;
 
 	onClick?: React.MouseEventHandler<HTMLDivElement>;
-	children?: React.ReactNode;
+	
 }
 
 const StyledLink = styled.div`

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -11,7 +11,7 @@ export interface MenuProps {
 	/** @name Sticky @default false */
 	sticky?: boolean;
 
-	children?: React.ReactNode;
+	
 }
 
 const StyledWrapper = styled(Layout)`

--- a/src/section/index.tsx
+++ b/src/section/index.tsx
@@ -10,7 +10,7 @@ export interface SectionProps {
 	/** @name Text Color */
 	textColor?: Color;
 
-	children?: React.ReactNode;
+	
 }
 
 const StyledWrapper = styled.div`


### PR DESCRIPTION
Remove all explicitly typed children properties as they are no longer needed. Depends on https://github.com/meetalva/alva/pull/689